### PR TITLE
Fix MTY_GetPlatform on Android

### DIFF
--- a/src/unix/linux/android/system.c
+++ b/src/unix/linux/android/system.c
@@ -25,7 +25,7 @@ uint32_t MTY_GetPlatform(void)
 
 	int32_t level = android_get_device_api_level();
 
-	v |= (uint32_t) level << 8;
+	v |= (uint32_t) level;
 
 	return v;
 }


### PR DESCRIPTION
The API level on Android is in the wrong part of the returned value of MTY_GetPlatform, according to the documentation.

/// @brief Get the current platform.
/// @returns An MTY_OS value bitwise OR'd with the OS's major and minor version numbers.
///   The major version has a mask of `0xFF00` and the minor has a mask of `0xFF`. On
///   Android, only a single version number is reported, the API level, in the
///   position of the minor number.

This PR resolves the issue by placing the API level in the position of the minor number as stated by the docs.