### PR TITLE
Revert "Fix MTY_GetPlatform on Android"

### DIFF
--- a/src/unix/linux/android/system.c
+++ b/src/unix/linux/android/system.c
@@ -25,7 +25,7 @@ uint32_t MTY_GetPlatform(void)
 
 	int32_t level = android_get_device_api_level();
 
-	v |= (uint32_t) level;
+	v |= (uint32_t) level << 8;
 
 	return v;
 }


### PR DESCRIPTION
Reverts parsec-cloud/libmatoya#12 - some consequences are unresolved.