### PR TITLE
MTY_AudioReset Windows bugfix

### DIFF
--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -295,13 +295,13 @@ void MTY_AudioReset(MTY_Audio *ctx)
 
 	if (ctx->playing) {
 		HRESULT e = IAudioClient_Stop(ctx->client);
-		if (e != S_OK) {
+		if (e != S_OK && e != S_FALSE) {
 			MTY_Log("'IAudioClient_Stop' failed with HRESULT 0x%X", e);
 			return;
 		}
 
 		e = IAudioClient_Reset(ctx->client);
-		if (e != S_OK) {
+		if (e != S_OK && e != S_FALSE) {
 			MTY_Log("'IAudioClient_Reset' failed with HRESULT 0x%X", e);
 			return;
 		}

--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -295,13 +295,13 @@ void MTY_AudioReset(MTY_Audio *ctx)
 
 	if (ctx->playing) {
 		HRESULT e = IAudioClient_Stop(ctx->client);
-		if (e != S_OK && e != S_FALSE) {
+		if (e != S_FALSE && e != S_OK) {
 			MTY_Log("'IAudioClient_Stop' failed with HRESULT 0x%X", e);
 			return;
 		}
 
 		e = IAudioClient_Reset(ctx->client);
-		if (e != S_OK && e != S_FALSE) {
+		if (e != S_FALSE && e != S_OK) {
 			MTY_Log("'IAudioClient_Reset' failed with HRESULT 0x%X", e);
 			return;
 		}


### PR DESCRIPTION
IAudioClient's Stop and Reset methods consider both S_OK and S_FALSE to be success states, where S_FALSE indicates the operation was already made.

> If the method succeeds and stops the stream, it returns S_OK. If the method succeeds and the stream was already stopped, the method returns S_FALSE.
\- [IAudioClient::Stop](https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-stop)

> If the method succeeds, it returns S_OK. If the method succeeds and the stream was already reset, the method returns S_FALSE.
\- [IAudioClient::Reset](https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-reset) 

Libmatoya currently considers S_FALSE to be an error state, causing potential log spam