### PR TITLE
[Minor] Ignore motion to the same position

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -747,8 +747,6 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			break;
 		case WM_MOUSEMOVE:
 			if (!app->filter_move && !pen_active && (!app->relative || app_hwnd_active(hwnd))) {
-				evt.motion.relative = false;
-				evt.motion.synth = false;
 				evt.motion.x = GET_X_LPARAM(lparam);
 				evt.motion.y = GET_Y_LPARAM(lparam);
 
@@ -756,6 +754,8 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 					break;
 
 				evt.type = MTY_EVENT_MOTION;
+				evt.motion.relative = false;
+				evt.motion.synth = false;
 				app->last_x = evt.motion.x;
 				app->last_y = evt.motion.y;
 			}

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -747,11 +747,17 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			break;
 		case WM_MOUSEMOVE:
 			if (!app->filter_move && !pen_active && (!app->relative || app_hwnd_active(hwnd))) {
-				evt.type = MTY_EVENT_MOTION;
 				evt.motion.relative = false;
 				evt.motion.synth = false;
 				evt.motion.x = GET_X_LPARAM(lparam);
 				evt.motion.y = GET_Y_LPARAM(lparam);
+
+				if (evt.motion.x == app->last_x && evt.motion.y == app->last_y)
+					break;
+
+				evt.type = MTY_EVENT_MOTION;
+				app->last_x = evt.motion.x;
+				app->last_y = evt.motion.y;
 			}
 
 			app->filter_move = false;


### PR DESCRIPTION
Stardock's Fences creates mouse motion messages once per second that can cause issues for applications acting on mouse motion.

This PR uses the existing app->lastx and app->lasty used for relative mode in order to deduplicate absolute mode mouse messages. 

This should have no effect on relative, since these values are set to -1 when switching modes.