### PR TITLE
Fix double-click Wintab binding

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -951,7 +951,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			// Wintab context only catches events on the main window, so we update the real one manually
 			struct window *new_ctx = (struct window *) GetWindowLongPtr(focused_window, 0);
 
-			pen_double_click = wintab_on_packet(app->wintab, &evt, &pkt, new_ctx->window);
+			wintab_on_packet(app->wintab, &evt, &pkt, new_ctx->window, &pen_double_click);
 
 			break;
 		}

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -683,6 +683,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 	bool creturn = false;
 	bool defreturn = false;
 	bool pen_active = app->pen_enabled && app->pen_in_range;
+	bool pen_double_click = false;
 	char drop_name[MTY_PATH_MAX];
 
 	switch (msg) {
@@ -950,7 +951,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			// Wintab context only catches events on the main window, so we update the real one manually
 			struct window *new_ctx = (struct window *) GetWindowLongPtr(focused_window, 0);
 
-			wintab_on_packet(app->wintab, &evt, &pkt, new_ctx->window);
+			pen_double_click = wintab_on_packet(app->wintab, &evt, &pkt, new_ctx->window);
 
 			break;
 		}
@@ -997,6 +998,13 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 	// Process the message
 	if (evt.type != MTY_EVENT_NONE) {
 		app->event_func(&evt, app->opaque);
+
+		if (pen_double_click) {
+			evt.pen.flags &= ~MTY_PEN_FLAG_TOUCHING;
+			app->event_func(&evt, app->opaque);
+			evt.pen.flags &= MTY_PEN_FLAG_TOUCHING;
+			app->event_func(&evt, app->opaque);
+		}
 
 		if (evt.type == MTY_EVENT_DROP)
 			MTY_Free((void *) evt.drop.buf);

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -29,8 +29,9 @@ struct wintab
 	PACKETEXT prev_pktext;
 	DWORD prev_buttons;
 
-	bool override;
 	int32_t max_pressure;
+	bool override;
+	bool has_double_clicked;
 };
 
 static bool wintab_find_extension(struct wintab *ctx, uint32_t searched_tag, uint32_t *index)
@@ -200,8 +201,11 @@ void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, void *p
 	wt.packet((HCTX) lparam, (UINT) wparam, pkt);
 }
 
-void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window)
+bool wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window)
 {
+	bool double_clicked = false;
+	bool has_double_clicked = ctx->has_double_clicked;
+
 	evt->type = MTY_EVENT_PEN;
 	evt->window = window;
 
@@ -209,7 +213,7 @@ void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY
 	evt->pen.y = (uint16_t) MTY_MAX(pkt->pkY, 0);
 	evt->pen.z = (uint16_t) MTY_MAX(pkt->pkZ, 0);
 
-	evt->pen.pressure = (uint16_t) (pkt->pkNormalPressure / (double) ctx->max_pressure * 1024.0);
+	evt->pen.pressure = (uint16_t) ((double) pkt->pkNormalPressure / (double) ctx->max_pressure * 1024.0);
 	evt->pen.rotation = (uint16_t) pkt->pkOrientation.orTwist;
 
 	#define sind(x) sin(fmod(x, 360) * M_PI / 180)
@@ -232,18 +236,18 @@ void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY
 		bool pressed      = pkt->pkButtons & (1 << i);
 		bool prev_pressed = ctx->prev_buttons & (1 << i);
 
+		bool left_click   = mapping[i] == SBN_LCLICK    || mapping[i] == SBN_LDBLCLICK;
 		bool right_click  = mapping[i] == SBN_RCLICK    || mapping[i] == SBN_RDBLCLICK;
 		bool double_click = mapping[i] == SBN_LDBLCLICK || mapping[i] == SBN_RDBLCLICK;
 
-		if (pressed && mapping[i] != SBN_NONE)
+		if ((left_click || right_click) && pressed)
 			evt->pen.flags |= MTY_PEN_FLAG_TOUCHING;
 
 		if (right_click && (pressed || prev_pressed))
 			evt->pen.flags |= MTY_PEN_FLAG_BARREL;
 
-		// Max pressure is set when double-clicking to mimic WinInk behavior
 		if (double_click)
-			evt->pen.pressure = 1024;
+			ctx->has_double_clicked = double_clicked = pressed;
 	}
 
 	if (evt->pen.flags & MTY_PEN_FLAG_TOUCHING && evt->pen.flags & MTY_PEN_FLAG_INVERTED)
@@ -251,6 +255,8 @@ void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY
 
 	ctx->prev_evt     = evt->pen;
 	ctx->prev_buttons = pkt->pkButtons;
+
+	return double_clicked && !has_double_clicked;
 }
 
 void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, const PACKETEXT *pktext)

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -201,9 +201,9 @@ void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, void *p
 	wt.packet((HCTX) lparam, (UINT) wparam, pkt);
 }
 
-bool wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window)
+void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window, bool *double_clicked)
 {
-	bool double_clicked = false;
+	*double_clicked = false;
 	bool has_double_clicked = ctx->has_double_clicked;
 
 	evt->type = MTY_EVENT_PEN;
@@ -247,7 +247,7 @@ bool wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY
 			evt->pen.flags |= MTY_PEN_FLAG_BARREL;
 
 		if (double_click)
-			ctx->has_double_clicked = double_clicked = pressed;
+			ctx->has_double_clicked = *double_clicked = pressed;
 	}
 
 	if (evt->pen.flags & MTY_PEN_FLAG_TOUCHING && evt->pen.flags & MTY_PEN_FLAG_INVERTED)
@@ -256,7 +256,7 @@ bool wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY
 	ctx->prev_evt     = evt->pen;
 	ctx->prev_buttons = pkt->pkButtons;
 
-	return double_clicked && !has_double_clicked;
+	*double_clicked = *double_clicked && !has_double_clicked;
 }
 
 void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, const PACKETEXT *pktext)

--- a/src/windows/wintab.h
+++ b/src/windows/wintab.h
@@ -24,6 +24,6 @@ void wintab_override_controls(struct wintab *ctx, bool override);
 
 void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, void *pkt);
 
-void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window);
+bool wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window);
 void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, const PACKETEXT *pktext);
 bool wintab_on_proximity(struct wintab *ctx, MTY_Event *evt, LPARAM lparam);

--- a/src/windows/wintab.h
+++ b/src/windows/wintab.h
@@ -24,6 +24,6 @@ void wintab_override_controls(struct wintab *ctx, bool override);
 
 void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, void *pkt);
 
-bool wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window);
+void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window, bool *double_clicked);
 void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, const PACKETEXT *pktext);
 bool wintab_on_proximity(struct wintab *ctx, MTY_Event *evt, LPARAM lparam);


### PR DESCRIPTION
Fixes an issue where the Wacom double-click binding was causing the pressure to be at its maximum. Since regular `WM_LBUTTON*` and `WM_RBUTTON*` are not processed while a pen is in range, and since we receive Wintab events indefinitely while the assigned barrel button is pressed, we need:
* To keep track of the button status inside the Wintab module, so we only send one double-click per down/up cycle
* To send additional MTY down/up events each time the Wintab module reports a double-click

Additionally, this PR fixes a conflict between Wacom middle-button binding and regular `WM_MBUTTON*`.