### PR TITLE
Fix JSON last item removal

### DIFF
--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1539,9 +1539,14 @@ CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON *const ite
 		/* not the first element */
 		item->prev->next = item->next;
 	}
+
 	if (item->next != NULL) {
 		/* not the last element */
 		item->next->prev = item->prev;
+
+	} else {
+		/* the last element */
+		parent->child->prev = item->prev;
 	}
 
 	if (item == parent->child) {

--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1543,16 +1543,17 @@ CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON *const ite
 	if (item->next != NULL) {
 		/* not the last element */
 		item->next->prev = item->prev;
-
-	} else {
-		/* the last element */
-		parent->child->prev = item->prev;
 	}
 
 	if (item == parent->child) {
 		/* first element */
 		parent->child = item->next;
+
+	} else if (item->next == NULL) {
+		/* last element */
+		parent->child->prev = item->prev;
 	}
+
 	/* make sure the detached item doesn't point anywhere anymore */
 	item->prev = NULL;
 	item->next = NULL;

--- a/test/json.h
+++ b/test/json.h
@@ -112,7 +112,7 @@ static void json_last_item(void)
 	MTY_JSONObjDeleteItem(root, "last");
 	MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
 	
-	MTY_JSONDestroy(root);
+	MTY_JSONDestroy(&root);
 }
 
 static bool json_main(void)

--- a/test/json.h
+++ b/test/json.h
@@ -105,12 +105,12 @@ static bool json_torture(void)
 // This will crash if it fails.
 static void json_last_item(void)
 {
-    const MTY_JSON *root = MTY_JSONObjCreate();
-    MTY_JSONObjSetItem(root, "child", MTY_JSONObjCreate());
+	const MTY_JSON *root = MTY_JSONObjCreate();
+	MTY_JSONObjSetItem(root, "child", MTY_JSONObjCreate());
 
-    MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
-    MTY_JSONObjDeleteItem(root, "last");
-    MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
+	MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
+	MTY_JSONObjDeleteItem(root, "last");
+	MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
 	
 	MTY_JSONDestroy(root);
 }

--- a/test/json.h
+++ b/test/json.h
@@ -102,11 +102,28 @@ static bool json_torture(void)
 	return true;
 }
 
+// This will crash if it fails.
+static void json_last_item(void)
+{
+    const MTY_JSON *root = MTY_JSONObjCreate();
+    MTY_JSONObjSetItem(root, "child", MTY_JSONObjCreate());
+
+    MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
+    MTY_JSONObjDeleteItem(root, "last");
+    MTY_JSONObjSetItem(root, "last", MTY_JSONObjCreate());
+	
+	MTY_JSONDestroy(root);
+}
+
 static bool json_main(void)
 {
-	for (uint8_t x = 0; x < 5; x++)
+	for (uint8_t x = 0; x < 5; x++) {
 		if (!json_torture())
 			return false;
+		
+		json_last_item();
+	}
+	
 
 	test_passed("JSON");
 


### PR DESCRIPTION
Removing the last item in a cJSON array does not update the array child's `->prev` reference to it.

This causes a crash if a new item is added to the array, because it attempts to modify the removed item.

This was fixed in cJSON upstream in April 2020. I modified my PR to match [this commit](https://github.com/DaveGamble/cJSON/commit/a65abf2f4f1842765761a616e93c14ae25a284fd)
