### PR TITLE
cJSON fixes

### DIFF
--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1663,6 +1663,10 @@ static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSO
 		CJSON_FREE(replacement->string);
 	}
 	replacement->string = (char *) MTY_Strdup(string);
+	if (replacement->string == NULL) {
+		return false;
+	}
+
 	replacement->type &= ~cJSON_StringIsConst;
 
 	return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string), replacement);

--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1809,6 +1809,9 @@ CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
 		}
 		child = child->next;
 	}
+	if (newitem && newitem->child) {
+		newitem->child->prev = newchild;
+	}
 
 	return newitem;
 

--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1629,6 +1629,9 @@ CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON *const parent, cJSON 
 		replacement->next->prev = replacement;
 	}
 	if (parent->child == item) {
+		if (parent->child->prev == parent->child) {
+			replacement->prev = replacement;
+		}
 		parent->child = replacement;
 	} else { /*
          * To find the last item in array quickly, we use prev in array.
@@ -1636,6 +1639,9 @@ CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON *const parent, cJSON 
          */
 		if (replacement->prev != NULL) {
 			replacement->prev->next = replacement;
+		}
+		if (replacement->next == NULL) {
+			parent->child->prev = replacement;
 		}
 	}
 

--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1475,12 +1475,6 @@ static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
 		if (child->prev) {
 			suffix_object(child->prev, item);
 			array->child->prev = item;
-		} else {
-			while (child->next) {
-				child = child->next;
-			}
-			suffix_object(child, item);
-			array->child->prev = item;
 		}
 	}
 


### PR DESCRIPTION
A couple of fixes from upstream, fixing bad child item replacement, ensuring child->prev is always present and valid, and taking advantage of that to speed up add_item_to_array / add_item_to_object

Currently on master, this will cause a crash;
```C
#include "matoya.h"

int32_t main(void)
{
    const MTY_JSON *root = MTY_JSONObjCreate();
    MTY_JSONObjSetBool(root, "child", false);  // OK
    MTY_JSONObjSetBool(root, "child", false);  // Breaks something
    MTY_JSONObjSetBool(root, "child->next", false);  // Crashes
    MTY_JSONDestroy(&root);
    return 0;
}
```
Because the replacement of "child" sets it's ->prev to the old child incorrectly, rather than to itself. So when child->next is set, it attempts to append to the the end of the object, the original child, causing an access violation as the original child has been freed