### PR TITLE
Missing ->prev setting

### DIFF
--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1113,6 +1113,10 @@ static cJSON_bool parse_array(cJSON *const item, parse_buffer *const input_buffe
 success:
 	input_buffer->depth--;
 
+	if (head != NULL) {
+		head->prev = current_item;
+	}
+
 	item->type = cJSON_Array;
 	item->child = head;
 
@@ -1261,6 +1265,10 @@ static cJSON_bool parse_object(cJSON *const item, parse_buffer *const input_buff
 
 success:
 	input_buffer->depth--;
+
+	if (head != NULL) {
+        head->prev = current_item;
+    }
 
 	item->type = cJSON_Object;
 	item->child = head;

--- a/deps/cJSON.h
+++ b/deps/cJSON.h
@@ -1267,8 +1267,8 @@ success:
 	input_buffer->depth--;
 
 	if (head != NULL) {
-        head->prev = current_item;
-    }
+		head->prev = current_item;
+	}
 
 	item->type = cJSON_Object;
 	item->child = head;


### PR DESCRIPTION
`MTY_JSONParse` would return MTY_JSON objects in which the child has no ->prev, breaking anything that relies on ->prev existing, such as MTY_JSONObjSetItem.

This PR pulls the missing logic from upstream, and has been tested to work.