### PR TITLE
Restore MTY_JSONString behavior.

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -855,7 +855,7 @@ bool MTY_JSONString(const MTY_JSON *json, char *value, size_t size)
 
 	int32_t n = snprintf(value, size, "%s", json->string);
 
-	return n >= 0 && (uint32_t) n < size;
+	return n >= 0;
 }
 
 const char *MTY_JSONFullString(const MTY_JSON *json)


### PR DESCRIPTION
This trims the strings, instead of failing.