### PR TITLE
Fix android audio flushing

### DIFF
--- a/src/unix/linux/android/audio.c
+++ b/src/unix/linux/android/audio.c
@@ -28,6 +28,7 @@ struct MTY_Audio {
 
 	uint8_t *buffer;
 	size_t size;
+	size_t min_request;
 };
 
 static void audio_error(AAudioStream *stream, void *userData, aaudio_result_t error)
@@ -47,6 +48,7 @@ static aaudio_data_callback_result_t audio_callback(AAudioStream *stream, void *
 	if (ctx->playing && ctx->size >= want_size) {
 		memcpy(audioData, ctx->buffer, want_size);
 		ctx->size -= want_size;
+		ctx->min_request = MTY_MIN(want_size, ctx->min_request);
 
 		memmove(ctx->buffer, ctx->buffer + want_size, ctx->size);
 
@@ -69,6 +71,7 @@ MTY_Audio *MTY_AudioCreate(uint32_t sampleRate, uint32_t minBuffer, uint32_t max
 	uint32_t frames_per_ms = lrint((float) sampleRate / 1000.0f);
 	ctx->min_buffer = minBuffer * frames_per_ms * AUDIO_CHANNELS * 2;
 	ctx->max_buffer = maxBuffer * frames_per_ms * AUDIO_CHANNELS * 2;
+	ctx->min_request = ctx->max_buffer;
 
 	return ctx;
 }
@@ -97,6 +100,7 @@ void MTY_AudioReset(MTY_Audio *ctx)
 		ctx->playing = false;
 		ctx->flushing = false;
 		ctx->size = 0;
+		ctx->min_request = ctx->max_buffer;
 
 		MTY_MutexUnlock(ctx->mutex);
 
@@ -145,6 +149,12 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 
 	if (ctx->size + data_size >= ctx->max_buffer)
 		ctx->flushing = true;
+
+	// If the data remaining is less than the minimum Android has ever requested, clear it so we don't get stuck flushing
+	if (ctx->flushing && ctx->size < ctx->min_request) {
+		memset(ctx->buffer, 0, ctx->size);
+		ctx->size = 0;
+	}
 
 	if (ctx->size == 0) {
 		ctx->playing = false;


### PR DESCRIPTION
In its flushing + playing state, the audio module could get stuck with less data than the callback to play it ever requests, permanently stopping audio playback until the MTY_Audio session is reset or otherwise ended.

I added some functionality to track the smallest request for audio frames, and discard the data left in the buffer if we're flushing, but have less data than the smallest request we've seen.

16/01/23;
What this PR actually does;
- Tracks the smallest size Android ever requests from the buffer
- If in the flushing state, and the buffer is smaller than the smallest size, clear whatever data remains to avoid locking up the audio