### PR TITLE
Stop forcing fullscreen on new window

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -1443,6 +1443,10 @@ MTY_Window MTY_WindowCreate(MTY_App *app, const char *title, const MTY_Frame *fr
 	if (frame->type & MTY_WINDOW_MAXIMIZED)
 		[ctx zoom:ctx];
 
+	// XXX Forcing fullscreen here does not seem required and causes issues in multi-screen setups
+	// if (frame->type & MTY_WINDOW_FULLSCREEN)
+	// 	MTY_WindowSetFullscreen(app, window, true);
+
 	if (!(frame->type & MTY_WINDOW_HIDDEN))
 		MTY_WindowActivate(app, window, true);
 
@@ -1546,6 +1550,10 @@ void MTY_WindowSetFrame(MTY_App *app, MTY_Window window, const MTY_Frame *frame)
 
 	if (frame->type & MTY_WINDOW_MAXIMIZED)
 		[ctx zoom:ctx];
+
+	// XXX Forcing fullscreen here does not seem required and causes issues in multi-screen setups
+	// if (frame->type & MTY_WINDOW_FULLSCREEN)
+	// 	MTY_WindowSetFullscreen(app, window, true);
 }
 
 void MTY_WindowSetMinSize(MTY_App *app, MTY_Window window, uint32_t minWidth, uint32_t minHeight)

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -1443,9 +1443,6 @@ MTY_Window MTY_WindowCreate(MTY_App *app, const char *title, const MTY_Frame *fr
 	if (frame->type & MTY_WINDOW_MAXIMIZED)
 		[ctx zoom:ctx];
 
-	if (frame->type & MTY_WINDOW_FULLSCREEN)
-		MTY_WindowSetFullscreen(app, window, true);
-
 	if (!(frame->type & MTY_WINDOW_HIDDEN))
 		MTY_WindowActivate(app, window, true);
 
@@ -1549,9 +1546,6 @@ void MTY_WindowSetFrame(MTY_App *app, MTY_Window window, const MTY_Frame *frame)
 
 	if (frame->type & MTY_WINDOW_MAXIMIZED)
 		[ctx zoom:ctx];
-
-	if (frame->type & MTY_WINDOW_FULLSCREEN)
-		MTY_WindowSetFullscreen(app, window, true);
 }
 
 void MTY_WindowSetMinSize(MTY_App *app, MTY_Window window, uint32_t minWidth, uint32_t minHeight)


### PR DESCRIPTION
On a MacOS window, forcefully toggling fullscreen is not required when the parent window is already in fullscreen mode. While this doesn't usually cause issues on single-screen setups, it does when moving a fullscreen tab to another screen. In that situation, if the second window is closed and re-opened from the parent one, the tab view disappear and a non-usable black fullscreen window is opened instead.

Here is a repro of the issue, and what behavior this PR fixes:

https://user-images.githubusercontent.com/6706489/200371713-b3eda9b0-e904-46ba-82d3-38bb52665caf.mp4

