### PR TITLE
Remove unnecessary DeleteFile from MoveFile fallback

### DIFF
--- a/src/windows/filew.c
+++ b/src/windows/filew.c
@@ -90,9 +90,6 @@ bool MTY_MoveFile(const char *src, const char *dst)
 		r = false;
 		DWORD last_error = GetLastError();
 		if (MTY_FileExists(src)) {
-			if (MTY_FileExists(dst))
-				MTY_DeleteFile(dst);
-
 			if (MTY_CopyFile(src, dst)) {
 				MTY_DeleteFile(src);
 				r = true;


### PR DESCRIPTION
Turns out the dst check pre-copy isn't necessary