### PR TITLE
Fix relative mode

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -542,7 +542,9 @@ static void window_mouse_button_event(Window *window, NSUInteger index, bool pre
 
 static void window_button_event(Window *window, NSEvent *event, NSUInteger index, bool pressed)
 {
-	if (window.app.pen_enabled && (event.buttonMask & NSEventButtonMaskPenTip || !index)) {
+	bool pen_in_range = event.subtype == NSTabletPointEventSubtype;
+
+	if (window.app.pen_enabled && pen_in_range && (event.buttonMask & NSEventButtonMaskPenTip || !index)) {
 		window_pen_event(window, event, pressed);
 
 	} else {

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -542,9 +542,9 @@ static void window_mouse_button_event(Window *window, NSUInteger index, bool pre
 
 static void window_button_event(Window *window, NSEvent *event, NSUInteger index, bool pressed)
 {
-	bool pen_in_range = event.subtype == NSTabletPointEventSubtype;
-
-	if (window.app.pen_enabled && pen_in_range && (event.buttonMask & NSEventButtonMaskPenTip || !index)) {
+	if (window.app.pen_enabled
+		&& (event.subtype == NSTabletPointEventSubtype)
+		&& (event.buttonMask & NSEventButtonMaskPenTip || !index)) {
 		window_pen_event(window, event, pressed);
 
 	} else {


### PR DESCRIPTION
According to the [Apple documentation](https://developer.apple.com/documentation/appkit/nsevent/1527828-buttonnumber), `NSEvent.buttonNumber` (which value is contained by `index` here) is supposed to return 0 in case of non-mouse event. However, 0 also seems to be set in some situations when relative mouse mode is on. This PR ensure the subtype of the event is a tablet event to avoid sending pen messages in this case.