### PR TITLE
Try to create the Wintab context only once

### DIFF
--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -141,7 +141,7 @@ struct wintab *wintab_create(HWND hwnd, bool override)
 	lc.lcPktData = PACKETDATA | touch_strip_mask | touch_ring_mask | exp_keys_mask;
 	lc.lcOutExtY = -lc.lcOutExtY;
 
-	ctx->context = NULL;//wt.open(hwnd, &lc, TRUE);
+	ctx->context = wt.open(hwnd, &lc, TRUE);
 	if (!ctx->context)
 		goto except;
 

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -137,7 +137,7 @@ struct wintab *wintab_create(HWND hwnd, bool override)
 	lc.lcPktData = PACKETDATA | touch_strip_mask | touch_ring_mask | exp_keys_mask;
 	lc.lcOutExtY = -lc.lcOutExtY;
 
-	ctx->context = NULL;//wt.open(hwnd, &lc, TRUE);
+	ctx->context = wt.open(GetAncestor(hwnd, GA_ROOT), &lc, TRUE);
 	if (!ctx->context)
 		goto except;
 

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -137,7 +137,7 @@ struct wintab *wintab_create(HWND hwnd, bool override)
 	lc.lcPktData = PACKETDATA | touch_strip_mask | touch_ring_mask | exp_keys_mask;
 	lc.lcOutExtY = -lc.lcOutExtY;
 
-	ctx->context = wt.open(hwnd, &lc, TRUE);
+	ctx->context = NULL;//wt.open(hwnd, &lc, TRUE);
 	if (!ctx->context)
 		goto except;
 

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -137,7 +137,7 @@ struct wintab *wintab_create(HWND hwnd, bool override)
 	lc.lcPktData = PACKETDATA | touch_strip_mask | touch_ring_mask | exp_keys_mask;
 	lc.lcOutExtY = -lc.lcOutExtY;
 
-	ctx->context = wt.open(GetAncestor(hwnd, GA_ROOT), &lc, TRUE);
+	ctx->context = NULL;//wt.open(hwnd, &lc, TRUE);
 	if (!ctx->context)
 		goto except;
 

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -14,6 +14,7 @@ typedef BOOL(API *WTOVERLAP)(HCTX, BOOL);
 
 static struct wt {
 	MTY_SO *instance;
+	bool failure;
 
 	WTINFOA  info;
 	WTOPENA  open;
@@ -87,6 +88,9 @@ static void wintab_override_extension(struct wintab *ctx, uint8_t tablet_i, uint
 
 struct wintab *wintab_create(HWND hwnd, bool override)
 {
+	if (wt.failure)
+		return NULL;
+
 	bool r = false;
 
 	struct wintab *ctx = MTY_Alloc(1, sizeof(struct wintab));
@@ -154,6 +158,7 @@ struct wintab *wintab_create(HWND hwnd, bool override)
 	if (!r) {
 		MTY_LogParams("Wacom", "Wintab context failed to initialize");
 		wintab_destroy(&ctx, true);
+		wt.failure = true;
 
 	} else {
 		MTY_LogParams("Wacom", "Wintab context successfully created");


### PR DESCRIPTION
Trying to create the Wintab context only once if a failure occurs has two benefits:
* It avoids trying to create the context each time the pen in enabled
* It prevents the context from being being created multiple times in multi-threaded applications