### PR TITLE
[Windows] Skip relative mouse inputs when detached

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -845,7 +845,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			}
 
 			RAWINPUTHEADER *header = &ctx->ri->header;
-			if (header->dwType == RIM_TYPEMOUSE) {
+			if (header->dwType == RIM_TYPEMOUSE && app->detach != MTY_DETACH_STATE_FULL) {
 				app_ri_relative_mouse(app, hwnd, ctx->ri, &evt);
 
 			} else if (header->dwType == RIM_TYPEHID) {


### PR DESCRIPTION
When the cursor is fully detached from the window while being in relative mouse mode, two `MTY_MotionEvent` are generated: one is absolute, the other is relative (see the output example at the end of this description). This PR fixes this behavior by looking at the detached state inside `WM_INPUT`, just before generating the relative motion event.

This also fixes a few Parsec issues (each occurs in a detached relative window):
* A left click is is not generated anymore when clicking outside the window.
* Moving the window does not generate relative motions and an held left click anymore.

Output example:
```
[0] MTY_EVENT_MOTION     x: 762, y: 470, relative: 0, synth: 0
[0] MTY_EVENT_MOTION     x: -3, y: 0, relative: 1, synth: 0
[0] MTY_EVENT_MOTION     x: 760, y: 470, relative: 0, synth: 0
[0] MTY_EVENT_MOTION     x: -1, y: 2, relative: 1, synth: 0
[0] MTY_EVENT_MOTION     x: 759, y: 471, relative: 0, synth: 0
[0] MTY_EVENT_MOTION     x: -1, y: 0, relative: 1, synth: 0
[0] MTY_EVENT_MOTION     x: 758, y: 471, relative: 0, synth: 0
[0] MTY_EVENT_MOTION     x: -1, y: 0, relative: 1, synth: 0
[0] MTY_EVENT_MOTION     x: 757, y: 471, relative: 0, synth: 0
[0] MTY_EVENT_MOTION     x: -1, y: 0, relative: 1, synth: 0
```