### PR TITLE
Fixes local clipboard corruption on X11 systems

### DIFF
--- a/src/unix/linux/x11/app.c
+++ b/src/unix/linux/x11/app.c
@@ -63,6 +63,9 @@ struct MTY_App {
 	char *clip;
 	float scale;
 
+	bool XfixesAvailable;
+	int XfixesEventBase;
+
 	uint64_t state;
 	uint64_t prev_state;
 };
@@ -254,9 +257,12 @@ static void app_handle_selection_notify(MTY_App *ctx, const XSelectionEvent *res
 
 		MTY_MutexUnlock(ctx->mutex);
 
-		// FIXME this is a questionable technique: will it interfere with other applications?
-		// We take back the selection so that we can be notified the next time a different app takes it
-		XSetSelectionOwner(ctx->display, XInternAtom(ctx->display, "CLIPBOARD", False), win0->window, CurrentTime);
+		if (!ctx->XfixesAvailable) {
+			// FIXME this is a questionable technique: will it interfere with other applications?
+			// We take back the selection so that we can be notified the next time a different app takes it
+			// corrected by Xfixes
+			XSetSelectionOwner(ctx->display, XInternAtom(ctx->display, "CLIPBOARD", False), win0->window, CurrentTime);
+		}
 
 		MTY_Event evt = {0};
 		evt.type = MTY_EVENT_CLIPBOARD;
@@ -269,7 +275,7 @@ static void app_poll_clipboard(MTY_App *ctx)
 	Atom clip = XInternAtom(ctx->display, "CLIPBOARD", False);
 
 	Window sel_owner = XGetSelectionOwner(ctx->display, clip);
-	if (sel_owner != ctx->sel_owner) {
+	if (sel_owner != ctx->sel_owner || ctx->XfixesAvailable) {
 		struct window *win0 = app_get_window(ctx, 0);
 
 		if (win0 && sel_owner != win0->window) {
@@ -531,6 +537,14 @@ static void app_event(MTY_App *ctx, XEvent *event)
 			}
 			ctx->state++;
 			break;
+        default:
+			if (ctx->XfixesAvailable)
+			{
+				if(event->type == ctx->XfixesEventBase + XFixesSelectionNotify) {
+					app_poll_clipboard(ctx);
+				}
+			}
+			break;
 	}
 
 	// Transform keyboard into hotkey
@@ -617,6 +631,7 @@ MTY_App *MTY_AppCreate(MTY_AppFunc appFunc, MTY_EventFunc eventFunc, void *opaqu
 	ctx->event_func = eventFunc;
 	ctx->opaque = opaque;
 	ctx->class_name = MTY_Strdup(MTY_GetFileName(MTY_GetProcessPath(), false));
+	ctx->XfixesAvailable = false;
 
 	// This may return NULL
 	ctx->evdev = mty_evdev_create(app_evdev_connect, app_evdev_disconnect, ctx);
@@ -660,6 +675,20 @@ MTY_App *MTY_AppCreate(MTY_AppFunc appFunc, MTY_EventFunc eventFunc, void *opaqu
 	ctx->wm_ping = XInternAtom(ctx->display, "_NET_WM_PING", False);
 
 	app_refresh_scale(ctx);
+
+	// Check if Xfixes is available for clipboard event
+	int error_base;
+	if (XFixesQueryExtension(ctx->display, &ctx->XfixesEventBase, &error_base)) {
+		int major, minor;
+		if (XFixesQueryVersion(ctx->display, &major, &minor)) {
+			if (major >= 1 && minor >= 0) {
+				ctx->XfixesAvailable = true;
+				XFixesSelectSelectionInput(ctx->display, XDefaultRootWindow(ctx->display),
+										XInternAtom(ctx->display, "CLIPBOARD", False),
+										XFixesSetSelectionOwnerNotifyMask);
+			}
+		}
+	}
 
 	except:
 
@@ -726,8 +755,10 @@ void MTY_AppRun(MTY_App *ctx)
 			ctx->prev_state = ctx->state;
 		}
 
-		// Poll selection ownership changes
-		app_poll_clipboard(ctx);
+		if (ctx->XfixesAvailable == false){
+			// Poll selection ownership changes
+			app_poll_clipboard(ctx);
+		}
 
 		// X11 events
 		for (XEvent event; XEventsQueued(ctx->display, QueuedAfterFlush) > 0;) {

--- a/src/unix/linux/x11/dl/libx11.c
+++ b/src/unix/linux/x11/dl/libx11.c
@@ -88,6 +88,10 @@ static XWMHints *(*XAllocWMHints)(void);
 static XClassHint *(*XAllocClassHint)(void);
 static int (*XResetScreenSaver)(Display *display);
 
+// Xfixes interface
+static bool (*XFixesQueryExtension)(Display *display, int *event_base_return, int *error_base_return);
+static bool (*XFixesQueryVersion)(Display *display, int *major_version_return, int *minor_version_return);
+static void (*XFixesSelectSelectionInput)(Display *display, Window window, Atom selection, unsigned long eventMask);
 
 // XKB interface (part of libX11 in modern times)
 
@@ -125,6 +129,7 @@ static MTY_SO *LIBGL_SO;
 static MTY_SO *LIBXI_SO;
 static MTY_SO *LIBXCURSOR_SO;
 static MTY_SO *LIBX11_SO;
+static MTY_SO *LIBXFIXES_SO;
 static bool LIBX11_INIT;
 
 static void __attribute__((destructor)) libX11_global_destroy(void)
@@ -135,6 +140,7 @@ static void __attribute__((destructor)) libX11_global_destroy(void)
 	MTY_SOUnload(&LIBXI_SO);
 	MTY_SOUnload(&LIBXCURSOR_SO);
 	MTY_SOUnload(&LIBX11_SO);
+	MTY_SOUnload(&LIBXFIXES_SO);
 	LIBX11_INIT = false;
 
 	MTY_GlobalUnlock(&LIBX11_LOCK);
@@ -148,6 +154,7 @@ static bool libX11_global_init(void)
 		bool r = true;
 
 		LIBX11_SO = MTY_SOLoad("libX11.so.6");
+		LIBXFIXES_SO = MTY_SOLoad("libXfixes.so");
 		LIBXI_SO = MTY_SOLoad("libXi.so.6");
 		LIBXCURSOR_SO = MTY_SOLoad("libXcursor.so.1");
 		LIBGL_SO = MTY_SOLoad("libGL.so.1");
@@ -217,6 +224,12 @@ static bool libX11_global_init(void)
 		LOAD_SYM(LIBX11_SO, XAllocWMHints);
 		LOAD_SYM(LIBX11_SO, XAllocClassHint);
 		LOAD_SYM(LIBX11_SO, XResetScreenSaver);
+
+		if (LIBXFIXES_SO) {
+			LOAD_SYM_OPT(LIBXFIXES_SO, XFixesQueryExtension);
+			LOAD_SYM_OPT(LIBXFIXES_SO, XFixesQueryVersion);
+			LOAD_SYM_OPT(LIBXFIXES_SO, XFixesSelectSelectionInput);
+		}
 
 		LOAD_SYM_OPT(LIBX11_SO, XkbSetDetectableAutoRepeat);
 

--- a/src/unix/linux/x11/dl/libx11.h
+++ b/src/unix/linux/x11/dl/libx11.h
@@ -58,6 +58,9 @@
 #define ColormapChangeMask        (1L<<23)
 #define OwnerGrabButtonMask       (1L<<24)
 
+#define XFixesSetSelectionOwnerNotifyMask   (1L << 0)
+#define XFixesSelectionNotify     0
+
 #define PropModeReplace           0
 #define PropModePrepend           1
 #define PropModeAppend            2


### PR DESCRIPTION
To resolve the issue of local clipboard corruption on Linux when non-text items are copied #81  , I suggest using "Xfixes" and the "XFixesSelectSelectionInput" function. This will allow us to retrieve events on clipboard modifications that are now available in most X11 engines today. However, for compatibility reasons, I will keep a retrocompatibility option in case Xfixes version 1.0 is not available.

This solution will help solve the problem of losing data and make it easier for users to transfer data between different applications. I have tested this solution on multiple X11 systems and it works as expected.

Please let me know if there are any concerns or questions regarding this proposal. Thank you!