### PR TITLE
Json surrogate pair bug

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -223,7 +223,7 @@ static bool json_utf16(const char *input, size_t len, uint32_t *p, char *str, si
 
 		*p += 6;
 
-		code = 0x10000 + ((code & 0x3FF) << 10 | (code2 & 0x3FF));
+		code = 0x10000 + (code & 0x3FF) << 10 + (code2 & 0x3FF);
 	}
 
 	*out += json_utf16_to_utf8(code, str + *out);

--- a/src/json.c
+++ b/src/json.c
@@ -223,7 +223,7 @@ static bool json_utf16(const char *input, size_t len, uint32_t *p, char *str, si
 
 		*p += 6;
 
-		code = 0x10000 | (code & 0x3FF) << 10 | (code2 & 0x3FF);
+		code = 0x10000 + (code & 0x3FF) << 10 | (code2 & 0x3FF);
 	}
 
 	*out += json_utf16_to_utf8(code, str + *out);

--- a/src/json.c
+++ b/src/json.c
@@ -223,7 +223,7 @@ static bool json_utf16(const char *input, size_t len, uint32_t *p, char *str, si
 
 		*p += 6;
 
-		code = 0x10000 + (code & 0x3FF) << 10 | (code2 & 0x3FF);
+		code = 0x10000 + ((code & 0x3FF) << 10 | (code2 & 0x3FF));
 	}
 
 	*out += json_utf16_to_utf8(code, str + *out);


### PR DESCRIPTION
because we used | instead of + in this expression, roughly half of unicode code points have never parsed correctly.
on the bright side, these code points are super vanishingly unlikely to ever appear in the wild.
this multi-year bug could have been avoided if we had written a test for the function that tested each of the 1,000,000 code points