### PR TITLE
Fix HID deduper leak in MTY_AppDestroy

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1085,7 +1085,7 @@ void MTY_AppDestroy(MTY_App **app)
 
 	MTY_HashDestroy(&ctx->hotkey, NULL);
 	MTY_HashDestroy(&ctx->ghotkey, NULL);
-	MTY_HashDestroy(&ctx->deduper, NULL);
+	MTY_HashDestroy(&ctx->deduper, MTY_Free);
 
 	for (MTY_Window x = 0; x < MTY_WINDOW_MAX; x++)
 		MTY_WindowDestroy(ctx, x);


### PR DESCRIPTION
The deduper allocates `MTY_ControllerEvent`s in `mty_hid_dedupe`, but `MTY_AppDestroy` destroys the `MTY_Hash` without freeing any of them