### PR TITLE
Simple AES256 support

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -1632,14 +1632,15 @@ MTY_GetRandomBytes(void *buf, size_t size);
 MTY_EXPORT uint32_t
 MTY_GetRandomUInt(uint32_t minVal, uint32_t maxVal);
 
-/// @brief Create an MTY_AESGCM context for AES-GCM-128/256 encryption/decryption.
+/// @brief Create an MTY_AESGCM context for AES-GCM encryption/decryption.
 /// @returns On failure, NULL is returned. Call MTY_GetLog for details.\n\n
 ///   The returned MTY_AESGCM context must be destroyed with MTY_AESGCMDestroy.
 /// @param key The secret key to use for encryption. This buffer must be 16 or 32
 ///   bytes, the size necessary for AES-128 or AES-256, respectively.
+/// @param keySize Size in bytes of `key`. Must be 16 or 32.
 //- #support Windows macOS Android Linux
 MTY_EXPORT MTY_AESGCM *
-MTY_AESGCMCreate(const void *key);
+MTY_AESGCMCreate(const void *key, size_t keySize);
 
 /// @brief Destroy an MTY_AESGCM context.
 /// @param aesgcm Passed by reference and set to NULL after being destroyed.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -1636,7 +1636,7 @@ MTY_GetRandomUInt(uint32_t minVal, uint32_t maxVal);
 /// @returns On failure, NULL is returned. Call MTY_GetLog for details.\n\n
 ///   The returned MTY_AESGCM context must be destroyed with MTY_AESGCMDestroy.
 /// @param key The secret key to use for encryption. This buffer must be 16 or 32
-///   bytes, the size necessary for AES-128 or AES-256, respectively.
+///   bytes, the size necessary for AES-GCM-128 or AES-GCM-256, respectively.
 /// @param keySize Size in bytes of `key`. Must be 16 or 32.
 //- #support Windows macOS Android Linux
 MTY_EXPORT MTY_AESGCM *
@@ -1648,7 +1648,7 @@ MTY_AESGCMCreate(const void *key, size_t keySize);
 MTY_EXPORT void
 MTY_AESGCMDestroy(MTY_AESGCM **aesgcm);
 
-/// @brief Encrypt plain text with a nonce using AES-GCM-128/256 and output the GCM tag.
+/// @brief Encrypt plain text with a nonce using AES-GCM and output the GCM tag.
 /// @param ctx An MTY_AESGCM context.
 /// @param nonce A buffer used as salt during encryption. This buffer must be 12 bytes,
 ///   and it MUST be different for each call to this function using the same
@@ -1664,7 +1664,7 @@ MTY_EXPORT bool
 MTY_AESGCMEncrypt(MTY_AESGCM *ctx, const void *nonce, const void *plainText, size_t size,
 	void *tag, void *cipherText);
 
-/// @brief Decrypt cipher text with a nonce and GCM tag using AES-GCM-128/256.
+/// @brief Decrypt cipher text with a nonce and GCM tag using AES-GCM.
 /// @param ctx An MTY_AESGCM context.
 /// @param nonce This buffer must be 12 bytes and it must match the `nonce` used
 ///   during encryption.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -1632,11 +1632,11 @@ MTY_GetRandomBytes(void *buf, size_t size);
 MTY_EXPORT uint32_t
 MTY_GetRandomUInt(uint32_t minVal, uint32_t maxVal);
 
-/// @brief Create an MTY_AESGCM context for AES-GCM-128 encryption/decryption.
+/// @brief Create an MTY_AESGCM context for AES-GCM-128/256 encryption/decryption.
 /// @returns On failure, NULL is returned. Call MTY_GetLog for details.\n\n
 ///   The returned MTY_AESGCM context must be destroyed with MTY_AESGCMDestroy.
-/// @param key The secret key to use for encryption. This buffer must be 16 bytes,
-///   the size necessary for AES-128.
+/// @param key The secret key to use for encryption. This buffer must be 16 or 32
+///   bytes, the size necessary for AES-128 or AES-256, respectively.
 //- #support Windows macOS Android Linux
 MTY_EXPORT MTY_AESGCM *
 MTY_AESGCMCreate(const void *key);
@@ -1647,7 +1647,7 @@ MTY_AESGCMCreate(const void *key);
 MTY_EXPORT void
 MTY_AESGCMDestroy(MTY_AESGCM **aesgcm);
 
-/// @brief Encrypt plain text with a nonce using AES-GCM-128 and output the GCM tag.
+/// @brief Encrypt plain text with a nonce using AES-GCM-128/256 and output the GCM tag.
 /// @param ctx An MTY_AESGCM context.
 /// @param nonce A buffer used as salt during encryption. This buffer must be 12 bytes,
 ///   and it MUST be different for each call to this function using the same
@@ -1663,7 +1663,7 @@ MTY_EXPORT bool
 MTY_AESGCMEncrypt(MTY_AESGCM *ctx, const void *nonce, const void *plainText, size_t size,
 	void *tag, void *cipherText);
 
-/// @brief Decrypt cipher text with a nonce and GCM tag using AES-GCM-128.
+/// @brief Decrypt cipher text with a nonce and GCM tag using AES-GCM-128/256.
 /// @param ctx An MTY_AESGCM context.
 /// @param nonce This buffer must be 12 bytes and it must match the `nonce` used
 ///   during encryption.

--- a/src/unix/apple/iphoneos/aes-gcm.c
+++ b/src/unix/apple/iphoneos/aes-gcm.c
@@ -339,6 +339,9 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
+	if (keySize != 16 && keySize != 32)
+		return NULL;
+
 	MTY_AESGCM *ctx = MTY_AllocAligned(sizeof(MTY_AESGCM), keySize);
 
 	aes_key_expansion(key, ctx->k);

--- a/src/unix/apple/iphoneos/aes-gcm.c
+++ b/src/unix/apple/iphoneos/aes-gcm.c
@@ -339,7 +339,7 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
-	if (keySize != 16 && keySize != 32)
+	if (keySize != 16)
 		return NULL;
 
 	MTY_AESGCM *ctx = MTY_AllocAligned(sizeof(MTY_AESGCM), keySize);

--- a/src/unix/apple/iphoneos/aes-gcm.c
+++ b/src/unix/apple/iphoneos/aes-gcm.c
@@ -337,7 +337,7 @@ struct MTY_AESGCM {
 	__m128i H[4];
 };
 
-MTY_AESGCM *MTY_AESGCMCreate(const void *key)
+MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
 	MTY_AESGCM *ctx = MTY_AllocAligned(sizeof(MTY_AESGCM), 16);
 

--- a/src/unix/apple/iphoneos/aes-gcm.c
+++ b/src/unix/apple/iphoneos/aes-gcm.c
@@ -339,7 +339,7 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
-	MTY_AESGCM *ctx = MTY_AllocAligned(sizeof(MTY_AESGCM), 16);
+	MTY_AESGCM *ctx = MTY_AllocAligned(sizeof(MTY_AESGCM), keySize);
 
 	aes_key_expansion(key, ctx->k);
 

--- a/src/unix/apple/macosx/aes-gcm.c
+++ b/src/unix/apple/macosx/aes-gcm.c
@@ -46,7 +46,7 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 		goto except;
 	}
 
-	e = CCCryptorCreateWithMode(kCCDecrypt, kCCModeGCM, algo,
+	e = CCCryptorCreateWithMode(kCCDecrypt, kCCModeGCM, kCCAlgorithmAES,
 		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->dec);
 	if (e != kCCSuccess) {
 		MTY_Log("'CCCryptoCreateWithMode' failed with error %d", e);

--- a/src/unix/apple/macosx/aes-gcm.c
+++ b/src/unix/apple/macosx/aes-gcm.c
@@ -33,15 +33,29 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 {
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
-	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, kCCAlgorithmAES128,
-		0, NULL, key, 16, NULL, 0, 0, 0, &ctx->enc);
+	size_t key_len = strlen(key);
+	uint32_t algo = kCCAlgorithmAES128;
+	switch (key_len) {
+		case 16:
+			break;
+		case 32:
+			algo = kCCAlgorithmAES256;
+			break;
+		default:
+			MTY_Log("invalid key length %zu", key_len);
+			e = kCCParamError;
+			goto except;
+	}
+
+	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, algo,
+		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->enc);
 	if (e != kCCSuccess) {
 		MTY_Log("'CCCryptoCreateWithMode' failed with error %d", e);
 		goto except;
 	}
 
-	e = CCCryptorCreateWithMode(kCCDecrypt, kCCModeGCM, kCCAlgorithmAES128,
-		0, NULL, key, 16, NULL, 0, 0, 0, &ctx->dec);
+	e = CCCryptorCreateWithMode(kCCDecrypt, kCCModeGCM, algo,
+		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->dec);
 	if (e != kCCSuccess) {
 		MTY_Log("'CCCryptoCreateWithMode' failed with error %d", e);
 		goto except;

--- a/src/unix/apple/macosx/aes-gcm.c
+++ b/src/unix/apple/macosx/aes-gcm.c
@@ -29,25 +29,19 @@ struct MTY_AESGCM {
 	CCCryptorRef enc;
 };
 
-MTY_AESGCM *MTY_AESGCMCreate(const void *key)
+MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
-	size_t key_len = strlen(key);
-	if (key_len != 16 && key_len != 32) {
-		MTY_Log("invalid key length %zu", key_len);
-		return NULL;
-	}
-
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
 	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, kCCAlgorithmAES,
-		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->enc);
+		0, NULL, key, keySize, NULL, 0, 0, 0, &ctx->enc);
 	if (e != kCCSuccess) {
 		MTY_Log("'CCCryptoCreateWithMode' failed with error %d", e);
 		goto except;
 	}
 
 	e = CCCryptorCreateWithMode(kCCDecrypt, kCCModeGCM, kCCAlgorithmAES,
-		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->dec);
+		0, NULL, key, keySize, NULL, 0, 0, 0, &ctx->dec);
 	if (e != kCCSuccess) {
 		MTY_Log("'CCCryptoCreateWithMode' failed with error %d", e);
 		goto except;

--- a/src/unix/apple/macosx/aes-gcm.c
+++ b/src/unix/apple/macosx/aes-gcm.c
@@ -31,6 +31,9 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
+	if (keySize != 16 && keySize != 32)
+		return NULL;
+
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
 	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, kCCAlgorithmAES,

--- a/src/unix/apple/macosx/aes-gcm.c
+++ b/src/unix/apple/macosx/aes-gcm.c
@@ -31,13 +31,13 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 {
-	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
-
 	size_t key_len = strlen(key);
 	if (key_len != 16 && key_len != 32) {
 		MTY_Log("invalid key length %zu", key_len);
-		goto except;
+		return NULL;
 	}
+
+	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
 	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, kCCAlgorithmAES,
 		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->enc);

--- a/src/unix/apple/macosx/aes-gcm.c
+++ b/src/unix/apple/macosx/aes-gcm.c
@@ -34,20 +34,12 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
 	size_t key_len = strlen(key);
-	uint32_t algo = kCCAlgorithmAES128;
-	switch (key_len) {
-		case 16:
-			break;
-		case 32:
-			algo = kCCAlgorithmAES256;
-			break;
-		default:
-			MTY_Log("invalid key length %zu", key_len);
-			e = kCCParamError;
-			goto except;
+	if (key_len != 16 && key_len != 32) {
+		MTY_Log("invalid key length %zu", key_len);
+		goto except;
 	}
 
-	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, algo,
+	CCCryptorStatus e = CCCryptorCreateWithMode(kCCEncrypt, kCCModeGCM, kCCAlgorithmAES,
 		0, NULL, key, key_len, NULL, 0, 0, 0, &ctx->enc);
 	if (e != kCCSuccess) {
 		MTY_Log("'CCCryptoCreateWithMode' failed with error %d", e);

--- a/src/unix/linux/android/aes-gcm.c
+++ b/src/unix/linux/android/aes-gcm.c
@@ -29,7 +29,7 @@ struct MTY_AESGCM {
 	jbyteArray buf[AES_GCM_NUM_BUFS];
 };
 
-MTY_AESGCM *MTY_AESGCMCreate(const void *key)
+MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
@@ -41,8 +41,7 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 	mty_jni_retain(env, &ctx->gcm);
 
 	// 128/256 bit AES key
-	size_t key_len = strlen(key);
-	jbyteArray jkey = mty_jni_dup(env, key, key_len);
+	jbyteArray jkey = mty_jni_dup(env, key, keySize);
 	jstring jalg_key = mty_jni_strdup(env, "AES");
 	ctx->key = mty_jni_new(env, "javax/crypto/spec/SecretKeySpec", "([BLjava/lang/String;)V", jkey, jalg_key);
 	mty_jni_retain(env, &ctx->key);

--- a/src/unix/linux/android/aes-gcm.c
+++ b/src/unix/linux/android/aes-gcm.c
@@ -40,8 +40,9 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 	ctx->gcm = mty_jni_static_obj(env, "javax/crypto/Cipher", "getInstance", "(Ljava/lang/String;)Ljavax/crypto/Cipher;", jalg);
 	mty_jni_retain(env, &ctx->gcm);
 
-	// 128 bit AES key
-	jbyteArray jkey = mty_jni_dup(env, key, 16);
+	// 128/256 bit AES key
+	size_t key_len = strlen(key);
+	jbyteArray jkey = mty_jni_dup(env, key, key_len);
 	jstring jalg_key = mty_jni_strdup(env, "AES");
 	ctx->key = mty_jni_new(env, "javax/crypto/spec/SecretKeySpec", "([BLjava/lang/String;)V", jkey, jalg_key);
 	mty_jni_retain(env, &ctx->key);

--- a/src/unix/linux/android/aes-gcm.c
+++ b/src/unix/linux/android/aes-gcm.c
@@ -31,6 +31,9 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
+	if (keySize != 16 && keySize != 32)
+		return NULL;
+
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 
 	JNIEnv *env = MTY_GetJNIEnv();

--- a/src/unix/linux/x11/aes-gcm.c
+++ b/src/unix/linux/x11/aes-gcm.c
@@ -13,7 +13,7 @@ struct MTY_AESGCM {
 	EVP_CIPHER_CTX *dec;
 };
 
-MTY_AESGCM *MTY_AESGCMCreate(const void *key)
+MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
 	if (!libcrypto_global_init())
 		return NULL;
@@ -21,9 +21,8 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 	bool r = true;
 
-	size_t key_len = strlen(key);
 	const EVP_CIPHER *cipher = NULL;
-	switch (key_len) {
+	switch (keySize) {
 		case 16:
 			cipher = EVP_aes_128_gcm();
 			break;
@@ -31,13 +30,12 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 			cipher = EVP_aes_256_gcm();
 			break;
 		default:
-			MTY_Log("invalid key length %zu", key_len);
-			r = false;
-			goto except;
+			MTY_Log("invalid key size %zu", keySize);
+			break;
 	}
 
 	if (!cipher) {
-		MTY_Log("'EVP_aes_x_gcm' failed");
+		MTY_Log("'EVP_aes_%d_gcm' failed", keySize * 8);
 		r = false;
 		goto except;
 	}

--- a/src/unix/linux/x11/aes-gcm.c
+++ b/src/unix/linux/x11/aes-gcm.c
@@ -2,6 +2,8 @@
 // If a copy of the MIT License was not distributed with this file,
 // You can obtain one at https://spdx.org/licenses/MIT.html.
 
+#include <string.h>
+
 #include "matoya.h"
 
 #include "dl/libcrypto.c"

--- a/src/unix/linux/x11/aes-gcm.c
+++ b/src/unix/linux/x11/aes-gcm.c
@@ -38,7 +38,7 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 	}
 
 	if (!cipher) {
-		MTY_Log("'EVP_aes_%d_gcm' failed", keySize * 8);
+		MTY_Log("'EVP_aes_%zu_gcm' failed", keySize * 8);
 		r = false;
 		goto except;
 	}

--- a/src/unix/linux/x11/aes-gcm.c
+++ b/src/unix/linux/x11/aes-gcm.c
@@ -15,6 +15,9 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
+	if (keySize != 16 && keySize != 32)
+		return NULL;
+
 	if (!libcrypto_global_init())
 		return NULL;
 

--- a/src/unix/linux/x11/aes-gcm.c
+++ b/src/unix/linux/x11/aes-gcm.c
@@ -19,7 +19,26 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 	bool r = true;
 
-	const EVP_CIPHER *cipher = EVP_aes_128_gcm();
+	size_t key_len = strlen(key);
+	const EVP_CIPHER *cipher = NULL;
+	switch (key_len) {
+		case 16:
+			cipher = EVP_aes_128_gcm();
+			break;
+		case 32:
+			cipher = EVP_aes_256_gcm();
+			break;
+		default:
+			MTY_Log("invalid key length %zu", key_len);
+			r = false;
+			goto except;
+	}
+
+	if (!cipher) {
+		MTY_Log("'EVP_aes_x_gcm' failed");
+		r = false;
+		goto except;
+	}
 
 	ctx->enc = EVP_CIPHER_CTX_new();
 	if (!ctx->enc) {

--- a/src/unix/linux/x11/dl/libcrypto.c
+++ b/src/unix/linux/x11/dl/libcrypto.c
@@ -10,6 +10,7 @@
 #include "sym.h"
 
 static const EVP_CIPHER *(*EVP_aes_128_gcm)(void);
+static const EVP_CIPHER *(*EVP_aes_256_gcm)(void);
 static EVP_CIPHER_CTX *(*EVP_CIPHER_CTX_new)(void);
 static void (*EVP_CIPHER_CTX_free)(EVP_CIPHER_CTX *c);
 static int (*EVP_CipherInit_ex)(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher, ENGINE *impl,
@@ -64,6 +65,7 @@ static bool libcrypto_global_init(void)
 		}
 
 		LOAD_SYM(LIBCRYPTO_SO, EVP_aes_128_gcm);
+		LOAD_SYM(LIBCRYPTO_SO, EVP_aes_256_gcm);
 		LOAD_SYM(LIBCRYPTO_SO, EVP_CIPHER_CTX_new);
 		LOAD_SYM(LIBCRYPTO_SO, EVP_CIPHER_CTX_free);
 		LOAD_SYM(LIBCRYPTO_SO, EVP_CipherInit_ex);

--- a/src/windows/aes-gcm.c
+++ b/src/windows/aes-gcm.c
@@ -17,6 +17,9 @@ struct MTY_AESGCM {
 
 MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
+	if (keySize != 16 && keySize != 32)
+		return NULL;
+
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 	bool r = true;
 

--- a/src/windows/aes-gcm.c
+++ b/src/windows/aes-gcm.c
@@ -15,17 +15,10 @@ struct MTY_AESGCM {
 	BCRYPT_KEY_HANDLE khandle;
 };
 
-MTY_AESGCM *MTY_AESGCMCreate(const void *key)
+MTY_AESGCM *MTY_AESGCMCreate(const void *key, size_t keySize)
 {
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 	bool r = true;
-
-	size_t key_len = strlen(key);
-	if (key_len != 16 && key_len != 32) {
-		MTY_Log("invalid key length %zu", key_len);
-		r = false;
-		goto except;
-	}
 
 	NTSTATUS e = BCryptOpenAlgorithmProvider(&ctx->ahandle, BCRYPT_AES_ALGORITHM, NULL, 0);
 	if (e != STATUS_SUCCESS) {
@@ -42,7 +35,7 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 		goto except;
 	}
 
-	e = BCryptGenerateSymmetricKey(ctx->ahandle, &ctx->khandle, NULL, 0, (UCHAR *) key, (ULONG) key_len, 0);
+	e = BCryptGenerateSymmetricKey(ctx->ahandle, &ctx->khandle, NULL, 0, (UCHAR *) key, (ULONG) keySize, 0);
 	if (e != STATUS_SUCCESS) {
 		MTY_Log("'BCryptGenerateSymmetricKey' failed with error 0x%X", e);
 		r = false;

--- a/src/windows/aes-gcm.c
+++ b/src/windows/aes-gcm.c
@@ -20,6 +20,13 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 	MTY_AESGCM *ctx = MTY_Alloc(1, sizeof(MTY_AESGCM));
 	bool r = true;
 
+	size_t key_len = strlen(key);
+	if (key_len != 16 && key_len != 32) {
+		MTY_Log("invalid key length %zu", key_len);
+		r = false;
+		goto except;
+	}
+
 	NTSTATUS e = BCryptOpenAlgorithmProvider(&ctx->ahandle, BCRYPT_AES_ALGORITHM, NULL, 0);
 	if (e != STATUS_SUCCESS) {
 		MTY_Log("'BCryptOpenAlgorithmProvider' failed with error 0x%X", e);
@@ -35,7 +42,7 @@ MTY_AESGCM *MTY_AESGCMCreate(const void *key)
 		goto except;
 	}
 
-	e = BCryptGenerateSymmetricKey(ctx->ahandle, &ctx->khandle, NULL, 0, (UCHAR *) key, 16, 0);
+	e = BCryptGenerateSymmetricKey(ctx->ahandle, &ctx->khandle, NULL, 0, (UCHAR *) key, (ULONG) key_len, 0);
 	if (e != STATUS_SUCCESS) {
 		MTY_Log("'BCryptGenerateSymmetricKey' failed with error 0x%X", e);
 		r = false;

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -29,6 +29,8 @@ CFLAGS := $(CFLAGS) -Wno-format-overflow
 LIBS = \
 	../bin/linux/$(ARCH)/libmatoya.a \
 	-lc \
+	-ldl \
+	-lpthread \
 	-lm
 endif
 

--- a/test/src/test/crypto.h
+++ b/test/src/test/crypto.h
@@ -3,66 +3,100 @@
 // If a copy of the MIT License was not distributed with this file,
 // You can obtain one at https://spdx.org/licenses/MIT.html.
 
-static bool validate_aesgcm()
+static bool validate_unknown_aesgcm()
 {
-	char *password1 = "1234567890123456";
-	char *password2 = "secret password!";
+	const char *password1 = "1234567890123456789012345678901212345678901234567890123456789012";
+
+	for (uint32_t i = 0; i < 64; i++) {
+		if (i != 16 && i != 32) {
+			MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1, i);
+			if (aes1 != NULL) {
+				MTY_AESGCMDestroy(&aes1);
+				test_cmp("MTY_AESGCMCreate %u", aes1 == NULL);
+			}
+		}
+	}
+
+	return true;
+}
+
+static bool validate_aesgcm_128()
+{
+	const uint8_t pre_encrypted[] = {
+		0xE5, 0x19, 0x0B, 0x88, 0x89, 0xE4, 0x3D, 0x6B, 0xCC, 0xD1, 0x59, 0xC7, 0x39, 0x46, 0x34, 0x64,
+		0xB0, 0x11, 0x00, 0x24, 0x35, 0xB6, 0xC1, 0xF8, 0x0C, 0xCE, 0xB5, 0x82, 0x4E, 0x5B, 0xFD, 0xFD,
+		0x42, 0x5C, 0x16, 0x67, 0x0D, 0x6B, 0x5D, 0x57, 0x91, 0x2A, 0x84, 0x65, 0xF3, 0x4E, 0x4E, 0x75,
+		0x8C, 0x00, 0x3A, 0xF4, 0xEF, 0x5F, 0x42, 0xA2, 0x79, 0x69, 0x48, 0xED, 0xE5, 0x85, 0x49, 0xAE,
+		0x24, 0x48, 0xDA
+	};
+	const char *password1 = "1234567890123456";
+	const char *password2 = "secret password!";
 	char nonce1[] = "123456789012";
-	char *nonce2 = "s3cr3t3stpas";
-	char *plain     = "The Quick Brown Fox Jumped Over The Super Lazy Dog!";
-	char *encrypted1 = calloc(1, strlen(plain));
-	char *encrypted2 = calloc(1, strlen(plain));
-	char *encrypted3 = calloc(1, strlen(plain));
-	char *decrypted = calloc(1, strlen(plain) + 1);
+	const char *nonce2 = "s3cr3t3stpas";
+	const char *plain     = "The Quick Brown Fox Jumped Over The Super Lazy Dog!";
+	const size_t len = strlen(plain);
+	char *encrypted1 = calloc(1, len);
+	char *encrypted2 = calloc(1, len);
+	char *encrypted3 = calloc(1, len);
+	char *decrypted = calloc(1, len + 1);
 	char *tag1 = calloc(1, 16);
 
 	MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1, 16);
-	test_cmp("MTY_AESGCMCreate", aes1 != NULL);
-	MTY_AESGCMEncrypt(aes1, nonce1, plain, strlen(plain), tag1, encrypted1);
+	test_cmp("MTY_AESGCMCreate 128", aes1 != NULL);
+	MTY_AESGCMEncrypt(aes1, nonce1, plain, len, tag1, encrypted1);
+	bool same = 0 == memcmp(pre_encrypted, encrypted1, len);
+	if (!same) {
+		char buffer[256] = {0};
+		MTY_BytesToHex(pre_encrypted, len, buffer, 256);
+		printf("Pre: %s\n", buffer);
+		MTY_BytesToHex(encrypted1, len, buffer, 256);
+		printf("Our: %s\n", buffer);
+	}
+	test_cmp("MTY_AESGCMEncrypt 128", same);
 
 	// Succeed
-	bool ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
-	test_cmp("MTY_AESGCMDecrypt", ok);
+	bool ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 128", ok);
 
 	// Encrypted data modified -- fail
 	encrypted1[3] = ~encrypted1[3];
-	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
-	test_cmp("MTY_AESGCMDecrypt", !ok);
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 128", !ok);
 
 	// Tag modified -- fail
 	encrypted1[3] = ~encrypted1[3];
 	tag1[3] = ~tag1[3];
-	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
-	test_cmp("MTY_AESGCMDecrypt", !ok);
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 128", !ok);
 
 	// Nonce modified -- fail
 	tag1[3] = ~tag1[3];
 	nonce1[3] = ~nonce1[3];
-	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
-	test_cmp("MTY_AESGCMDecrypt", !ok);
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 128", !ok);
 
 	// Back to normal -- succeed
 	nonce1[3] = ~nonce1[3];
-	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
-	test_cmp("MTY_AESGCMDecrypt", ok);
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 128", ok);
 
 	MTY_AESGCMDestroy(&aes1);
 
 	aes1 = MTY_AESGCMCreate(password2, 16);
-	MTY_AESGCMEncrypt(aes1, nonce1, plain, strlen(plain), tag1, encrypted2);
+	MTY_AESGCMEncrypt(aes1, nonce1, plain, len, tag1, encrypted2);
 	MTY_AESGCMDestroy(&aes1);
-	int32_t cmp_encr_1 = memcmp(encrypted1, encrypted2, strlen(plain));
+	int32_t cmp_encr_1 = memcmp(encrypted1, encrypted2, len);
 
 
 	aes1 = MTY_AESGCMCreate(password1, 16);
-	test_cmp("MTY_AESGCMCreate", aes1 != NULL);
-	MTY_AESGCMEncrypt(aes1, nonce2, plain, strlen(plain), tag1, encrypted3);
+	test_cmp("MTY_AESGCMCreate 128", aes1 != NULL);
+	MTY_AESGCMEncrypt(aes1, nonce2, plain, len, tag1, encrypted3);
 	MTY_AESGCMDestroy(&aes1);
-	int32_t cmp_encr_2 = memcmp(encrypted1, encrypted3, strlen(plain));
-	int32_t cmp_encr_3 = memcmp(encrypted2, encrypted3, strlen(plain));
+	int32_t cmp_encr_2 = memcmp(encrypted1, encrypted3, len);
+	int32_t cmp_encr_3 = memcmp(encrypted2, encrypted3, len);
 
 	aes1 = MTY_AESGCMCreate(password1, 16);
-	MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
+	MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_decr = strcmp(decrypted, plain);
 	free(encrypted3);
@@ -71,12 +105,107 @@ static bool validate_aesgcm()
 	free(decrypted);
 	free(tag1);
 
-	test_cmp("MTY_AESGCMDestroy", aes1 == NULL);
+	test_cmp("MTY_AESGCMDestroy 128", aes1 == NULL);
 
-	test_cmp("MTY_AESGCMDecrypt", cmp_decr == 0);
-	test_cmp("MTY_AESGCMEncrypt", cmp_encr_1 != 0);
-	test_cmp("MTY_AESGCMEncrypt", cmp_encr_2 != 0);
-	test_cmp("MTY_AESGCMEncrypt", cmp_encr_3 != 0);
+	test_cmp("MTY_AESGCMDecrypt 128", cmp_decr == 0);
+	test_cmp("MTY_AESGCMEncrypt 128", cmp_encr_1 != 0);
+	test_cmp("MTY_AESGCMEncrypt 128", cmp_encr_2 != 0);
+	test_cmp("MTY_AESGCMEncrypt 128", cmp_encr_3 != 0);
+
+	return true;
+}
+
+static bool validate_aesgcm_256()
+{
+	const uint8_t pre_encrypted[] = {
+		0xD4, 0x9A, 0x98, 0xCE, 0x53, 0x34, 0xA8, 0x82, 0x8E, 0x32, 0x7D, 0xF6, 0xBE, 0x62, 0x06, 0x7C,
+		0x58, 0xD1, 0x6E, 0xD4, 0x35, 0x87, 0xD0, 0x04, 0x6C, 0x87, 0x68, 0xD2, 0x97, 0x8B, 0xD6, 0x91,
+		0x28, 0xDB, 0xC5, 0x00, 0x79, 0xC1, 0x43, 0x47, 0x0D, 0x24, 0x60, 0x0C, 0x34, 0xE1, 0x30, 0xFD,
+		0xE2, 0x5F, 0xBB, 0x68, 0x63, 0xFA, 0x5D, 0x72, 0x81, 0xFD, 0x2F, 0x73, 0x3A, 0x34, 0x0B, 0x05,
+		0x20, 0x8A, 0x4D
+	};
+	const char *password1 = "12345678901234567890123456789012";
+	const char *password2 = "secret password!secret password!";
+	char nonce1[] = "123456789012";
+	const char *nonce2 = "s3cr3t3stpas";
+	const char *plain     = "The Quick Brown Fox Jumped Over The Super Lazy Dog!";
+	const size_t len = strlen(plain);
+	char *encrypted1 = calloc(1, len);
+	char *encrypted2 = calloc(1, len);
+	char *encrypted3 = calloc(1, len);
+	char *decrypted = calloc(1, len + 1);
+	char *tag1 = calloc(1, 32);
+
+	MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1, 32);
+	test_cmp("MTY_AESGCMCreate 256", aes1 != NULL);
+	MTY_AESGCMEncrypt(aes1, nonce1, plain, len, tag1, encrypted1);
+	bool same = 0 == memcmp(pre_encrypted, encrypted1, len);
+	if (!same) {
+		char buffer[256] = {0};
+		MTY_BytesToHex(pre_encrypted, len, buffer, 256);
+		printf("Pre: %s\n", buffer);
+		MTY_BytesToHex(encrypted1, len, buffer, 256);
+		printf("Our: %s\n", buffer);
+	}
+	test_cmp("MTY_AESGCMEncrypt 256", same);
+
+	// Succeed
+	bool ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 256", ok);
+
+	// Encrypted data modified -- fail
+	encrypted1[3] = ~encrypted1[3];
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 256", !ok);
+
+	// Tag modified -- fail
+	encrypted1[3] = ~encrypted1[3];
+	tag1[3] = ~tag1[3];
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 256", !ok);
+
+	// Nonce modified -- fail
+	tag1[3] = ~tag1[3];
+	nonce1[3] = ~nonce1[3];
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 256", !ok);
+
+	// Back to normal -- succeed
+	nonce1[3] = ~nonce1[3];
+	ok = MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	test_cmp("MTY_AESGCMDecrypt 256", ok);
+
+	MTY_AESGCMDestroy(&aes1);
+
+	aes1 = MTY_AESGCMCreate(password2, 32);
+	MTY_AESGCMEncrypt(aes1, nonce1, plain, len, tag1, encrypted2);
+	MTY_AESGCMDestroy(&aes1);
+	int32_t cmp_encr_1 = memcmp(encrypted1, encrypted2, len);
+
+
+	aes1 = MTY_AESGCMCreate(password1, 32);
+	test_cmp("MTY_AESGCMCreate 256", aes1 != NULL);
+	MTY_AESGCMEncrypt(aes1, nonce2, plain, len, tag1, encrypted3);
+	MTY_AESGCMDestroy(&aes1);
+	int32_t cmp_encr_2 = memcmp(encrypted1, encrypted3, len);
+	int32_t cmp_encr_3 = memcmp(encrypted2, encrypted3, len);
+
+	aes1 = MTY_AESGCMCreate(password1, 32);
+	MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, len, tag1, decrypted);
+	MTY_AESGCMDestroy(&aes1);
+	int32_t cmp_decr = strcmp(decrypted, plain);
+	free(encrypted3);
+	free(encrypted2);
+	free(encrypted1);
+	free(decrypted);
+	free(tag1);
+
+	test_cmp("MTY_AESGCMDestroy 256", aes1 == NULL);
+
+	test_cmp("MTY_AESGCMDecrypt 256", cmp_decr == 0);
+	test_cmp("MTY_AESGCMEncrypt 256", cmp_encr_1 != 0);
+	test_cmp("MTY_AESGCMEncrypt 256", cmp_encr_2 != 0);
+	test_cmp("MTY_AESGCMEncrypt 256", cmp_encr_3 != 0);
 
 	return true;
 }
@@ -285,7 +414,13 @@ static bool crypto_main()
 	if (!validate_random())
 		return false;
 
-	if (!validate_aesgcm())
+	if (!validate_unknown_aesgcm())
+		return false;
+
+	if (!validate_aesgcm_128())
+		return false;
+
+	if (!validate_aesgcm_256())
 		return false;
 
 	return true;

--- a/test/src/test/crypto.h
+++ b/test/src/test/crypto.h
@@ -16,7 +16,7 @@ static bool validate_aesgcm()
 	char *decrypted = calloc(1, strlen(plain) + 1);
 	char *tag1 = calloc(1, 16);
 
-	MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1, false);
+	MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1, 16);
 	test_cmp("MTY_AESGCMCreate", aes1 != NULL);
 	MTY_AESGCMEncrypt(aes1, nonce1, plain, strlen(plain), tag1, encrypted1);
 
@@ -48,20 +48,20 @@ static bool validate_aesgcm()
 
 	MTY_AESGCMDestroy(&aes1);
 
-	aes1 = MTY_AESGCMCreate(password2, false);
+	aes1 = MTY_AESGCMCreate(password2, 16);
 	MTY_AESGCMEncrypt(aes1, nonce1, plain, strlen(plain), tag1, encrypted2);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_encr_1 = memcmp(encrypted1, encrypted2, strlen(plain));
 
 
-	aes1 = MTY_AESGCMCreate(password1, false);
+	aes1 = MTY_AESGCMCreate(password1, 16);
 	test_cmp("MTY_AESGCMCreate", aes1 != NULL);
 	MTY_AESGCMEncrypt(aes1, nonce2, plain, strlen(plain), tag1, encrypted3);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_encr_2 = memcmp(encrypted1, encrypted3, strlen(plain));
 	int32_t cmp_encr_3 = memcmp(encrypted2, encrypted3, strlen(plain));
 
-	aes1 = MTY_AESGCMCreate(password1, false);
+	aes1 = MTY_AESGCMCreate(password1, 16);
 	MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_decr = strcmp(decrypted, plain);

--- a/test/src/test/crypto.h
+++ b/test/src/test/crypto.h
@@ -3,7 +3,7 @@
 // If a copy of the MIT License was not distributed with this file,
 // You can obtain one at https://spdx.org/licenses/MIT.html.
 
-static bool validate_unknown_aesgcm()
+static bool validate_unknown_aesgcm(void)
 {
 	const char *password1 = "1234567890123456789012345678901212345678901234567890123456789012";
 
@@ -20,7 +20,7 @@ static bool validate_unknown_aesgcm()
 	return true;
 }
 
-static bool validate_aesgcm_128()
+static bool validate_aesgcm_128(void)
 {
 	const uint8_t pre_encrypted[] = {
 		0xE5, 0x19, 0x0B, 0x88, 0x89, 0xE4, 0x3D, 0x6B, 0xCC, 0xD1, 0x59, 0xC7, 0x39, 0x46, 0x34, 0x64,
@@ -115,7 +115,7 @@ static bool validate_aesgcm_128()
 	return true;
 }
 
-static bool validate_aesgcm_256()
+static bool validate_aesgcm_256(void)
 {
 	const uint8_t pre_encrypted[] = {
 		0xD4, 0x9A, 0x98, 0xCE, 0x53, 0x34, 0xA8, 0x82, 0x8E, 0x32, 0x7D, 0xF6, 0xBE, 0x62, 0x06, 0x7C,
@@ -210,7 +210,7 @@ static bool validate_aesgcm_256()
 	return true;
 }
 
-static bool validate_random()
+static bool validate_random(void)
 {
 	int32_t random_size = 1 * 1024 * 1024;
 	uint32_t distribution[256] = {0};
@@ -286,7 +286,7 @@ static bool validate_sha256_hmac(const char *hmac, const char *data, const char 
 	return true;
 }
 
-static bool validate_cryptohash()
+static bool validate_cryptohash(void)
 {
 	/*
 	MTY_ALGORITHM_SHA1
@@ -375,7 +375,7 @@ static bool validate_cryptohash()
 	return true;
 }
 
-static bool validate_djb2()
+static bool validate_djb2(void)
 {
 	uint32_t crc = MTY_DJB2("123456789");
 	test_cmp_("CRC32 1", crc == 0x35cdbb82, "123456789", ": \"%s\"");
@@ -388,7 +388,7 @@ static bool validate_djb2()
 
 }
 
-static bool validate_crc32()
+static bool validate_crc32(void)
 {
 	uint32_t crc = MTY_CRC32(0, "123456789", 9);
 	test_cmp_("CRC32 1", crc == 0xcbf43926, "123456789", ": \"%s\"");
@@ -400,7 +400,7 @@ static bool validate_crc32()
 	return true;
 }
 
-static bool crypto_main()
+static bool crypto_main(void)
 {
 	if (!validate_crc32())
 		return false;

--- a/test/src/test/crypto.h
+++ b/test/src/test/crypto.h
@@ -16,7 +16,7 @@ static bool validate_aesgcm()
 	char *decrypted = calloc(1, strlen(plain) + 1);
 	char *tag1 = calloc(1, 16);
 
-	MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1);
+	MTY_AESGCM *aes1 = MTY_AESGCMCreate(password1, false);
 	test_cmp("MTY_AESGCMCreate", aes1 != NULL);
 	MTY_AESGCMEncrypt(aes1, nonce1, plain, strlen(plain), tag1, encrypted1);
 
@@ -48,20 +48,20 @@ static bool validate_aesgcm()
 
 	MTY_AESGCMDestroy(&aes1);
 
-	aes1 = MTY_AESGCMCreate(password2);
+	aes1 = MTY_AESGCMCreate(password2, false);
 	MTY_AESGCMEncrypt(aes1, nonce1, plain, strlen(plain), tag1, encrypted2);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_encr_1 = memcmp(encrypted1, encrypted2, strlen(plain));
 
 
-	aes1 = MTY_AESGCMCreate(password1);
+	aes1 = MTY_AESGCMCreate(password1, false);
 	test_cmp("MTY_AESGCMCreate", aes1 != NULL);
 	MTY_AESGCMEncrypt(aes1, nonce2, plain, strlen(plain), tag1, encrypted3);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_encr_2 = memcmp(encrypted1, encrypted3, strlen(plain));
 	int32_t cmp_encr_3 = memcmp(encrypted2, encrypted3, strlen(plain));
 
-	aes1 = MTY_AESGCMCreate(password1);
+	aes1 = MTY_AESGCMCreate(password1, false);
 	MTY_AESGCMDecrypt(aes1, nonce1, encrypted1, strlen(plain), tag1, decrypted);
 	MTY_AESGCMDestroy(&aes1);
 	int32_t cmp_decr = strcmp(decrypted, plain);


### PR DESCRIPTION
Adds AES-GCM-256 support to the existing AES-GCM-128 functions, selecting the type based on the length of key provided.