### PR TITLE
functions to convert unicode were not threadsafe except on Windows

### DIFF
--- a/src/unix/memory.c
+++ b/src/unix/memory.c
@@ -45,9 +45,11 @@ char *MTY_Strtok(char *str, const char *delim, char **saveptr)
 	return strtok_r(str, delim, saveptr);
 }
 
+__thread mbstate_t mbstate;
+
 bool MTY_WideToMulti(const wchar_t *src, char *dst, size_t size)
 {
-	size_t n = wcstombs(dst, src, size);
+	size_t n = wcsrtombs(dst, &src, size, &mbstate);
 
 	if (n > 0 && n != (size_t) -1) {
 		if (n == size) {
@@ -65,7 +67,7 @@ bool MTY_WideToMulti(const wchar_t *src, char *dst, size_t size)
 
 bool MTY_MultiToWide(const char *src, wchar_t *dst, uint32_t len)
 {
-	size_t n = mbstowcs(dst, src, len);
+	size_t n = mbsrtowcs(dst, &src, len, &mbstate);
 
 	if (n > 0 && n != (size_t) -1) {
 		if (n == len) {


### PR DESCRIPTION
the docs for mbstowcs and wcstombs explicitly say that these functions are not re-entrant, yet they are presented as part of a threadsafe API. like with strok_r, we should call only the threadsafe variants of these functions.

good news, however: parsec never calls MTY_WideToMulti and MTY_MultiToWide on non-Windows platforms, because they serve no practical purpose. on Windows they convert utf8<=>ut16 which is useful for Windows and JSON. Elsewhere they convert utf8<=>utf32, which is never useful anywhere. therefore parsec has been in no danger of the race conditions caused by these non-threadsafe functions.

we should not, however, ship an API that purports to be threadsafe and is not.