### PR TITLE
MTY_SprintfDL is unsafe, but is also very slow.

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -112,14 +112,13 @@ const char *MTY_SprintfDL(const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
-
-	char *str = MTY_VsprintfD(fmt, args);
-
+	va_list args_copy;
+	va_copy(args_copy, args);
+	const size_t size = vsnprintf(NULL, 0, fmt, args_copy) + 1;
+	va_end(args_copy);
+	char *local = mty_tlocal(size);
+	vsnprintf(local, size, fmt, args);
 	va_end(args);
-
-	char *local = mty_tlocal_strcpy(str);
-	MTY_Free(str);
-
 	return local;
 }
 


### PR DESCRIPTION
MTY_SprintfDL is unsafe because it uses thread-local memory, but is also very slow because it calls malloc/free. There is no reason to have the worst of both worlds. In this PR we no longer call malloc/free in MTY_SprintfDL.