### PR TITLE
[Linux - Fix] Dynamic libraries no longer deadlock when missing, and use the correct headers

### DIFF
--- a/src/unix/linux/x11/dl/libasound.h
+++ b/src/unix/linux/x11/dl/libasound.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <alsa/asoundlib.h>
+
 #include <alloca.h>
 #include <errno.h>
 
@@ -12,142 +14,39 @@
 
 // Interface
 
-typedef struct _snd_pcm snd_pcm_t;
-typedef struct _snd_pcm_hw_params snd_pcm_hw_params_t;
-typedef struct _snd_pcm_status snd_pcm_status_t;
-typedef unsigned long snd_pcm_uframes_t;
-typedef long snd_pcm_sframes_t;
+static int (*snd_pcm_open_ptr)(snd_pcm_t **pcm, const char *name, snd_pcm_stream_t stream, int mode);
+static int (*snd_pcm_hw_params_any_ptr)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params);
+static int (*snd_pcm_hw_params_set_access_ptr)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_access_t _access);
+static int (*snd_pcm_hw_params_set_format_ptr)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_format_t val);
+static int (*snd_pcm_hw_params_set_channels_ptr)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val);
+static int (*snd_pcm_hw_params_set_rate_ptr)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val, int dir);
+static int (*snd_pcm_hw_params_ptr)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params);
+static int (*snd_pcm_prepare_ptr)(snd_pcm_t *pcm);
+static snd_pcm_sframes_t (*snd_pcm_writei_ptr)(snd_pcm_t *pcm, const void *buffer, snd_pcm_uframes_t size);
+static int (*snd_pcm_close_ptr)(snd_pcm_t *pcm);
+static int (*snd_pcm_nonblock_ptr)(snd_pcm_t *pcm, int nonblock);
+static int (*snd_pcm_status_ptr)(snd_pcm_t *pcm, snd_pcm_status_t *status);
+static size_t (*snd_pcm_status_sizeof_ptr)(void);
+static size_t (*snd_pcm_hw_params_sizeof_ptr)(void);
+static snd_pcm_uframes_t (*snd_pcm_status_get_avail_ptr)(const snd_pcm_status_t *obj);
+static snd_pcm_uframes_t (*snd_pcm_status_get_avail_max_ptr)(const snd_pcm_status_t *obj);
 
-typedef enum _snd_pcm_stream {
-	SND_PCM_STREAM_PLAYBACK = 0,
-	SND_PCM_STREAM_CAPTURE,
-	SND_PCM_STREAM_LAST = SND_PCM_STREAM_CAPTURE
-} snd_pcm_stream_t;
-
-typedef enum _snd_pcm_access {
-	SND_PCM_ACCESS_MMAP_INTERLEAVED = 0,
-	SND_PCM_ACCESS_MMAP_NONINTERLEAVED,
-	SND_PCM_ACCESS_MMAP_COMPLEX,
-	SND_PCM_ACCESS_RW_INTERLEAVED,
-	SND_PCM_ACCESS_RW_NONINTERLEAVED,
-	SND_PCM_ACCESS_LAST = SND_PCM_ACCESS_RW_NONINTERLEAVED
-} snd_pcm_access_t;
-
-typedef enum _snd_pcm_format {
-	SND_PCM_FORMAT_UNKNOWN = -1,
-	SND_PCM_FORMAT_S8 = 0,
-	SND_PCM_FORMAT_U8,
-	SND_PCM_FORMAT_S16_LE,
-	SND_PCM_FORMAT_S16_BE,
-	SND_PCM_FORMAT_U16_LE,
-	SND_PCM_FORMAT_U16_BE,
-	SND_PCM_FORMAT_S24_LE,
-	SND_PCM_FORMAT_S24_BE,
-	SND_PCM_FORMAT_U24_LE,
-	SND_PCM_FORMAT_U24_BE,
-	SND_PCM_FORMAT_S32_LE,
-	SND_PCM_FORMAT_S32_BE,
-	SND_PCM_FORMAT_U32_LE,
-	SND_PCM_FORMAT_U32_BE,
-	SND_PCM_FORMAT_FLOAT_LE,
-	SND_PCM_FORMAT_FLOAT_BE,
-	SND_PCM_FORMAT_FLOAT64_LE,
-	SND_PCM_FORMAT_FLOAT64_BE,
-	SND_PCM_FORMAT_IEC958_SUBFRAME_LE,
-	SND_PCM_FORMAT_IEC958_SUBFRAME_BE,
-	SND_PCM_FORMAT_MU_LAW,
-	SND_PCM_FORMAT_A_LAW,
-	SND_PCM_FORMAT_IMA_ADPCM,
-	SND_PCM_FORMAT_MPEG,
-	SND_PCM_FORMAT_GSM,
-	SND_PCM_FORMAT_S20_LE,
-	SND_PCM_FORMAT_S20_BE,
-	SND_PCM_FORMAT_U20_LE,
-	SND_PCM_FORMAT_U20_BE,
-	SND_PCM_FORMAT_SPECIAL = 31,
-	SND_PCM_FORMAT_S24_3LE = 32,
-	SND_PCM_FORMAT_S24_3BE,
-	SND_PCM_FORMAT_U24_3LE,
-	SND_PCM_FORMAT_U24_3BE,
-	SND_PCM_FORMAT_S20_3LE,
-	SND_PCM_FORMAT_S20_3BE,
-	SND_PCM_FORMAT_U20_3LE,
-	SND_PCM_FORMAT_U20_3BE,
-	SND_PCM_FORMAT_S18_3LE,
-	SND_PCM_FORMAT_S18_3BE,
-	SND_PCM_FORMAT_U18_3LE,
-	SND_PCM_FORMAT_U18_3BE,
-	/* G.723 (ADPCM) 24 kbit/s, 8 samples in 3 bytes */
-	SND_PCM_FORMAT_G723_24,
-	/* G.723 (ADPCM) 24 kbit/s, 1 sample in 1 byte */
-	SND_PCM_FORMAT_G723_24_1B,
-	/* G.723 (ADPCM) 40 kbit/s, 8 samples in 3 bytes */
-	SND_PCM_FORMAT_G723_40,
-	/* G.723 (ADPCM) 40 kbit/s, 1 sample in 1 byte */
-	SND_PCM_FORMAT_G723_40_1B,
-	/* Direct Stream Digital (DSD) in 1-byte samples (x8) */
-	SND_PCM_FORMAT_DSD_U8,
-	/* Direct Stream Digital (DSD) in 2-byte samples (x16) */
-	SND_PCM_FORMAT_DSD_U16_LE,
-	/* Direct Stream Digital (DSD) in 4-byte samples (x32) */
-	SND_PCM_FORMAT_DSD_U32_LE,
-	/* Direct Stream Digital (DSD) in 2-byte samples (x16) */
-	SND_PCM_FORMAT_DSD_U16_BE,
-	/* Direct Stream Digital (DSD) in 4-byte samples (x32) */
-	SND_PCM_FORMAT_DSD_U32_BE,
-	SND_PCM_FORMAT_LAST = SND_PCM_FORMAT_DSD_U32_BE,
-
-	#if __BYTE_ORDER == __LITTLE_ENDIAN
-
-	SND_PCM_FORMAT_S16 = SND_PCM_FORMAT_S16_LE,
-	SND_PCM_FORMAT_U16 = SND_PCM_FORMAT_U16_LE,
-	SND_PCM_FORMAT_S24 = SND_PCM_FORMAT_S24_LE,
-	SND_PCM_FORMAT_U24 = SND_PCM_FORMAT_U24_LE,
-	SND_PCM_FORMAT_S32 = SND_PCM_FORMAT_S32_LE,
-	SND_PCM_FORMAT_U32 = SND_PCM_FORMAT_U32_LE,
-	SND_PCM_FORMAT_FLOAT = SND_PCM_FORMAT_FLOAT_LE,
-	SND_PCM_FORMAT_FLOAT64 = SND_PCM_FORMAT_FLOAT64_LE,
-	SND_PCM_FORMAT_IEC958_SUBFRAME = SND_PCM_FORMAT_IEC958_SUBFRAME_LE,
-	SND_PCM_FORMAT_S20 = SND_PCM_FORMAT_S20_LE,
-	SND_PCM_FORMAT_U20 = SND_PCM_FORMAT_U20_LE,
-	#elif __BYTE_ORDER == __BIG_ENDIAN
-
-	SND_PCM_FORMAT_S16 = SND_PCM_FORMAT_S16_BE,
-	SND_PCM_FORMAT_U16 = SND_PCM_FORMAT_U16_BE,
-	SND_PCM_FORMAT_S24 = SND_PCM_FORMAT_S24_BE,
-	SND_PCM_FORMAT_U24 = SND_PCM_FORMAT_U24_BE,
-	SND_PCM_FORMAT_S32 = SND_PCM_FORMAT_S32_BE,
-	SND_PCM_FORMAT_U32 = SND_PCM_FORMAT_U32_BE,
-	SND_PCM_FORMAT_FLOAT = SND_PCM_FORMAT_FLOAT_BE,
-	SND_PCM_FORMAT_FLOAT64 = SND_PCM_FORMAT_FLOAT64_BE,
-	SND_PCM_FORMAT_IEC958_SUBFRAME = SND_PCM_FORMAT_IEC958_SUBFRAME_BE,
-	SND_PCM_FORMAT_S20 = SND_PCM_FORMAT_S20_BE,
-	SND_PCM_FORMAT_U20 = SND_PCM_FORMAT_U20_BE,
-	#else
-	#error "Unknown endian"
-	#endif
-} snd_pcm_format_t;
-
-#define	__snd_alloca(ptr, type)       do {*ptr = (type##_t *) alloca(type##_sizeof()); memset(*ptr, 0, type##_sizeof());} while (0)
-#define snd_pcm_status_alloca(ptr)    __snd_alloca(ptr, snd_pcm_status)
-#define snd_pcm_hw_params_alloca(ptr) __snd_alloca(ptr, snd_pcm_hw_params)
-
-static int (*snd_pcm_open)(snd_pcm_t **pcm, const char *name, snd_pcm_stream_t stream, int mode);
-static int (*snd_pcm_hw_params_any)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params);
-static int (*snd_pcm_hw_params_set_access)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_access_t _access);
-static int (*snd_pcm_hw_params_set_format)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_format_t val);
-static int (*snd_pcm_hw_params_set_channels)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val);
-static int (*snd_pcm_hw_params_set_rate)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val, int dir);
-static int (*snd_pcm_hw_params)(snd_pcm_t *pcm, snd_pcm_hw_params_t *params);
-static int (*snd_pcm_prepare)(snd_pcm_t *pcm);
-static snd_pcm_sframes_t (*snd_pcm_writei)(snd_pcm_t *pcm, const void *buffer, snd_pcm_uframes_t size);
-static int (*snd_pcm_close)(snd_pcm_t *pcm);
-static int (*snd_pcm_nonblock)(snd_pcm_t *pcm, int nonblock);
-static int (*snd_pcm_status)(snd_pcm_t *pcm, snd_pcm_status_t *status);
-static size_t (*snd_pcm_status_sizeof)(void);
-static size_t (*snd_pcm_hw_params_sizeof)(void);
-static snd_pcm_uframes_t (*snd_pcm_status_get_avail)(const snd_pcm_status_t *obj);
-static snd_pcm_uframes_t (*snd_pcm_status_get_avail_max)(const snd_pcm_status_t *obj);
+#define snd_pcm_open snd_pcm_open_ptr
+#define snd_pcm_hw_params_any snd_pcm_hw_params_any_ptr
+#define snd_pcm_hw_params_set_access snd_pcm_hw_params_set_access_ptr
+#define snd_pcm_hw_params_set_format snd_pcm_hw_params_set_format_ptr
+#define snd_pcm_hw_params_set_channels snd_pcm_hw_params_set_channels_ptr
+#define snd_pcm_hw_params_set_rate snd_pcm_hw_params_set_rate_ptr
+#define snd_pcm_hw_params snd_pcm_hw_params_ptr
+#define snd_pcm_prepare snd_pcm_prepare_ptr
+#define snd_pcm_writei snd_pcm_writei_ptr
+#define snd_pcm_close snd_pcm_close_ptr
+#define snd_pcm_nonblock snd_pcm_nonblock_ptr
+#define snd_pcm_status snd_pcm_status_ptr
+#define snd_pcm_status_sizeof snd_pcm_status_sizeof_ptr
+#define snd_pcm_hw_params_sizeof snd_pcm_hw_params_sizeof_ptr
+#define snd_pcm_status_get_avail snd_pcm_status_get_avail_ptr
+#define snd_pcm_status_get_avail_max snd_pcm_status_get_avail_max_ptr
 
 
 // Runtime open

--- a/src/unix/linux/x11/dl/libasound.h
+++ b/src/unix/linux/x11/dl/libasound.h
@@ -64,7 +64,9 @@ static void libasound_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libasound_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBASOUND_LOCK);
+
 	libasound_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBASOUND_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libasound.h
+++ b/src/unix/linux/x11/dl/libasound.h
@@ -55,13 +55,16 @@ static MTY_Atomic32 LIBASOUND_LOCK;
 static MTY_SO *LIBASOUND_SO;
 static bool LIBASOUND_INIT;
 
+static void libasound_global_destroy_lockfree(void)
+{
+	MTY_SOUnload(&LIBASOUND_SO);
+	LIBASOUND_INIT = false;
+}
+
 static void __attribute__((destructor)) libasound_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBASOUND_LOCK);
-
-	MTY_SOUnload(&LIBASOUND_SO);
-	LIBASOUND_INIT = false;
-
+	libasound_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBASOUND_LOCK);
 }
 
@@ -99,7 +102,7 @@ static bool libasound_global_init(void)
 		except:
 
 		if (!r)
-			libasound_global_destroy();
+			libasound_global_destroy_lockfree();
 
 		LIBASOUND_INIT = r;
 	}

--- a/src/unix/linux/x11/dl/libcrypto.c
+++ b/src/unix/linux/x11/dl/libcrypto.c
@@ -44,7 +44,9 @@ static void libcrypto_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libcrypto_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBCRYPTO_LOCK);
+
 	libcrypto_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBCRYPTO_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libcurl.h
+++ b/src/unix/linux/x11/dl/libcurl.h
@@ -119,7 +119,9 @@ static void libcurl_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libcurl_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBCURL_LOCK);
+
 	libcurl_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBCURL_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libcurl.h
+++ b/src/unix/linux/x11/dl/libcurl.h
@@ -110,13 +110,16 @@ static MTY_Atomic32 LIBCURL_LOCK;
 static MTY_SO *LIBCURL_SO;
 static bool LIBCURL_INIT;
 
+static void libcurl_global_destroy_lockfree(void)
+{
+	MTY_SOUnload(&LIBCURL_SO);
+	LIBCURL_INIT = false;
+}
+
 static void __attribute__((destructor)) libcurl_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBCURL_LOCK);
-
-	MTY_SOUnload(&LIBCURL_SO);
-	LIBCURL_INIT = false;
-
+	libcurl_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBCURL_LOCK);
 }
 
@@ -160,7 +163,7 @@ static bool libcurl_global_init(void)
 		except:
 
 		if (!r)
-			libcurl_global_destroy();
+			libcurl_global_destroy_lockfree();
 
 		LIBCURL_INIT = r;
 	}

--- a/src/unix/linux/x11/dl/libjpeg.h
+++ b/src/unix/linux/x11/dl/libjpeg.h
@@ -4,222 +4,29 @@
 
 #pragma once
 
+#include <jpeglib.h>
+
 #include "sym.h"
 
 
 // Interface
+static struct jpeg_error_mgr *(*jpeg_std_error_ptr)(struct jpeg_error_mgr *err);
+static void (*jpeg_CreateDecompress_ptr)(j_decompress_ptr cinfo, int version, size_t structsize);
+static void (*jpeg_mem_src_ptr)(j_decompress_ptr cinfo, void *buffer, long nbytes);
+static int (*jpeg_read_header_ptr)(j_decompress_ptr cinfo, boolean require_image);
+static boolean (*jpeg_start_decompress_ptr)(j_decompress_ptr cinfo);
+static JDIMENSION (*jpeg_read_scanlines_ptr)(j_decompress_ptr cinfo, JSAMPARRAY scanlines, JDIMENSION max_lines);
+static boolean (*jpeg_finish_decompress_ptr)(j_decompress_ptr cinfo);
+static void (*jpeg_destroy_decompress_ptr)(j_decompress_ptr cinfo);
 
-#define DCTSIZE2            64
-#define NUM_QUANT_TBLS      4
-#define NUM_HUFF_TBLS       4
-#define NUM_ARITH_TBLS      16
-#define MAX_COMPS_IN_SCAN   4
-#define D_MAX_BLOCKS_IN_MCU 10
-#define JMSG_STR_PARM_MAX   80
-#define JPEG_LIB_VERSION    80
-#define JPEG_HEADER_OK      1
-
-#define TRUE  1
-#define FALSE 0
-
-#define jpeg_common_fields \
-	struct jpeg_error_mgr *err; \
-	struct jpeg_memory_mgr *mem; \
-	struct jpeg_progress_mgr *progress; \
-	void *client_data; \
-	boolean is_decompressor; \
-	int global_state
-
-#define JMETHOD(type, methodname, arglist) type (*methodname) arglist
-
-typedef int boolean;
-typedef unsigned char UINT8;
-typedef unsigned short UINT16;
-typedef unsigned int JDIMENSION;
-typedef unsigned char JSAMPLE;
-
-typedef JSAMPLE *JSAMPROW;
-typedef JSAMPROW *JSAMPARRAY;
-typedef struct jpeg_marker_struct *jpeg_saved_marker_ptr;
-typedef struct jpeg_common_struct *j_common_ptr;
-typedef struct jpeg_decompress_struct *j_decompress_ptr;
-
-typedef enum {
-	JCS_UNKNOWN,
-	JCS_GRAYSCALE,
-	JCS_RGB,
-	JCS_YCbCr,
-	JCS_CMYK,
-	JCS_YCCK
-} J_COLOR_SPACE;
-
-typedef enum {
-	JDCT_ISLOW,
-	JDCT_IFAST,
-	JDCT_FLOAT
-} J_DCT_METHOD;
-
-typedef enum {
-	JDITHER_NONE,
-	JDITHER_ORDERED,
-	JDITHER_FS
-} J_DITHER_MODE;
-
-typedef struct {
-	UINT8 bits[17];
-	UINT8 huffval[256];
-	boolean sent_table;
-} JHUFF_TBL;
-
-typedef struct {
-	UINT16 quantval[DCTSIZE2];
-	boolean sent_table;
-} JQUANT_TBL;
-
-struct jpeg_common_struct {
-	jpeg_common_fields;
-};
-
-struct jpeg_error_mgr {
-	JMETHOD(void, error_exit, (j_common_ptr cinfo));
-	JMETHOD(void, emit_message, (j_common_ptr cinfo, int msg_level));
-	JMETHOD(void, output_message, (j_common_ptr cinfo));
-	JMETHOD(void, format_message, (j_common_ptr cinfo, char *buffer));
-	JMETHOD(void, reset_error_mgr, (j_common_ptr cinfo));
-	int msg_code;
-	union {
-		int i[8];
-		char s[JMSG_STR_PARM_MAX];
-	} msg_parm;
-	int trace_level;
-	long num_warnings;
-	const char * const *jpeg_message_table;
-	int last_jpeg_message;
-	const char * const *addon_message_table;
-	int first_addon_message;
-	int last_addon_message;
-};
-
-typedef struct {
-	int component_id;
-	int component_index;
-	int h_samp_factor;
-	int v_samp_factor;
-	int quant_tbl_no;
-	int dc_tbl_no;
-	int ac_tbl_no;
-	JDIMENSION width_in_blocks;
-	JDIMENSION height_in_blocks;
-	int DCT_h_scaled_size;
-	int DCT_v_scaled_size;
-	JDIMENSION downsampled_width;
-	JDIMENSION downsampled_height;
-	boolean component_needed;
-	int MCU_width;
-	int MCU_height;
-	int MCU_blocks;
-	int MCU_sample_width;
-	int last_col_width;
-	int last_row_height;
-	JQUANT_TBL *quant_table;
-	void *dct_table;
-} jpeg_component_info;
-
-struct jpeg_decompress_struct {
-	jpeg_common_fields;
-	struct jpeg_source_mgr *src;
-	JDIMENSION image_width;
-	JDIMENSION image_height;
-	int num_components;
-	J_COLOR_SPACE jpeg_color_space;
-	J_COLOR_SPACE out_color_space;
-	unsigned int scale_num, scale_denom;
-	double output_gamma;
-	boolean buffered_image;
-	boolean raw_data_out;
-	J_DCT_METHOD dct_method;
-	boolean do_fancy_upsampling;
-	boolean do_block_smoothing;
-	boolean quantize_colors;
-	J_DITHER_MODE dither_mode;
-	boolean two_pass_quantize;
-	int desired_number_of_colors;
-	boolean enable_1pass_quant;
-	boolean enable_external_quant;
-	boolean enable_2pass_quant;
-	JDIMENSION output_width;
-	JDIMENSION output_height;
-	int out_color_components;
-	int output_components;
-	int rec_outbuf_height;
-	int actual_number_of_colors;
-	JSAMPARRAY colormap;
-	JDIMENSION output_scanline;
-	int input_scan_number;
-	JDIMENSION input_iMCU_row;
-	int output_scan_number;
-	JDIMENSION output_iMCU_row;
-	int (*coef_bits)[DCTSIZE2];
-	JQUANT_TBL *quant_tbl_ptrs[NUM_QUANT_TBLS];
-	JHUFF_TBL *dc_huff_tbl_ptrs[NUM_HUFF_TBLS];
-	JHUFF_TBL *ac_huff_tbl_ptrs[NUM_HUFF_TBLS];
-	int data_precision;
-	jpeg_component_info *comp_info;
-	boolean is_baseline;
-	boolean progressive_mode;
-	boolean arith_code;
-	UINT8 arith_dc_L[NUM_ARITH_TBLS];
-	UINT8 arith_dc_U[NUM_ARITH_TBLS];
-	UINT8 arith_ac_K[NUM_ARITH_TBLS];
-	unsigned int restart_interval;
-	boolean saw_JFIF_marker;
-	UINT8 JFIF_major_version;
-	UINT8 JFIF_minor_version;
-	UINT8 density_unit;
-	UINT16 X_density;
-	UINT16 Y_density;
-	boolean saw_Adobe_marker;
-	UINT8 Adobe_transform;
-	boolean CCIR601_sampling;
-	jpeg_saved_marker_ptr marker_list;
-	int max_h_samp_factor;
-	int max_v_samp_factor;
-	int min_DCT_h_scaled_size;
-	int min_DCT_v_scaled_size;
-	JDIMENSION total_iMCU_rows;
-	JSAMPLE *sample_range_limit;
-	int comps_in_scan;
-	jpeg_component_info *cur_comp_info[MAX_COMPS_IN_SCAN];
-	JDIMENSION MCUs_per_row;
-	JDIMENSION MCU_rows_in_scan;
-	int blocks_in_MCU;
-	int MCU_membership[D_MAX_BLOCKS_IN_MCU];
-	int Ss, Se, Ah, Al;
-	int block_size;
-	const int *natural_order;
-	int lim_Se;
-	int unread_marker;
-	struct jpeg_decomp_master *master;
-	struct jpeg_d_main_controller *main;
-	struct jpeg_d_coef_controller *coef;
-	struct jpeg_d_post_controller *post;
-	struct jpeg_input_controller *inputctl;
-	struct jpeg_marker_reader *marker;
-	struct jpeg_entropy_decoder *entropy;
-	struct jpeg_inverse_dct *idct;
-	struct jpeg_upsampler *upsample;
-	struct jpeg_color_deconverter *cconvert;
-	struct jpeg_color_quantizer *cquantize;
-};
-
-static struct jpeg_error_mgr *(*jpeg_std_error)(struct jpeg_error_mgr *err);
-static void (*jpeg_CreateDecompress)(j_decompress_ptr cinfo, int version, size_t structsize);
-static void (*jpeg_mem_src)(j_decompress_ptr cinfo, void *buffer, long nbytes);
-static int (*jpeg_read_header)(j_decompress_ptr cinfo, boolean require_image);
-static boolean (*jpeg_start_decompress)(j_decompress_ptr cinfo);
-static JDIMENSION (*jpeg_read_scanlines)(j_decompress_ptr cinfo, JSAMPARRAY scanlines, JDIMENSION max_lines);
-static boolean (*jpeg_finish_decompress)(j_decompress_ptr cinfo);
-static void (*jpeg_destroy_decompress)(j_decompress_ptr cinfo);
+#define jpeg_std_error jpeg_std_error_ptr
+#define jpeg_CreateDecompress jpeg_CreateDecompress_ptr
+#define jpeg_mem_src jpeg_mem_src_ptr
+#define jpeg_read_header jpeg_read_header_ptr
+#define jpeg_start_decompress jpeg_start_decompress_ptr
+#define jpeg_read_scanlines jpeg_read_scanlines_ptr
+#define jpeg_finish_decompress jpeg_finish_decompress_ptr
+#define jpeg_destroy_decompress jpeg_destroy_decompress_ptr
 
 
 // Runtime open
@@ -246,6 +53,12 @@ static bool libjpeg_global_init(void)
 		bool r = true;
 
 		LIBJPEG_SO = MTY_SOLoad("libjpeg.so.8");
+		if (!LIBJPEG_SO)
+			LIBJPEG_SO = MTY_SOLoad("libjpeg.so.62");
+
+		if (!LIBJPEG_SO)
+			LIBJPEG_SO = MTY_SOLoad("libjpeg.so");
+
 		if (!LIBJPEG_SO) {
 			r = false;
 			goto except;

--- a/src/unix/linux/x11/dl/libjpeg.h
+++ b/src/unix/linux/x11/dl/libjpeg.h
@@ -35,13 +35,16 @@ static MTY_Atomic32 LIBJPEG_LOCK;
 static MTY_SO *LIBJPEG_SO;
 static bool LIBJPEG_INIT;
 
+static void libjpeg_global_destroy_lockfree(void)
+{
+	MTY_SOUnload(&LIBJPEG_SO);
+	LIBJPEG_INIT = false;
+}
+
 static void __attribute__((destructor)) libjpeg_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBJPEG_LOCK);
-
-	MTY_SOUnload(&LIBJPEG_SO);
-	LIBJPEG_INIT = false;
-
+	libjpeg_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBJPEG_LOCK);
 }
 
@@ -76,7 +79,7 @@ static bool libjpeg_global_init(void)
 		except:
 
 		if (!r)
-			libjpeg_global_destroy();
+			libjpeg_global_destroy_lockfree();
 
 		LIBJPEG_INIT = r;
 	}

--- a/src/unix/linux/x11/dl/libpng.h
+++ b/src/unix/linux/x11/dl/libpng.h
@@ -61,7 +61,9 @@ static void libpng_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libpng_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBPNG_LOCK);
+
 	libpng_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBPNG_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libpng.h
+++ b/src/unix/linux/x11/dl/libpng.h
@@ -52,13 +52,16 @@ static MTY_Atomic32 LIBPNG_LOCK;
 static MTY_SO *LIBPNG_SO;
 static bool LIBPNG_INIT;
 
+static void libpng_global_destroy_lockfree(void)
+{
+	MTY_SOUnload(&LIBPNG_SO);
+	LIBPNG_INIT = false;
+}
+
 static void __attribute__((destructor)) libpng_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBPNG_LOCK);
-
-	MTY_SOUnload(&LIBPNG_SO);
-	LIBPNG_INIT = false;
-
+	libpng_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBPNG_LOCK);
 }
 
@@ -100,7 +103,7 @@ static bool libpng_global_init(void)
 		except:
 
 		if (!r)
-			libpng_global_destroy();
+			libpng_global_destroy_lockfree();
 
 		LIBPNG_INIT = r;
 	}

--- a/src/unix/linux/x11/dl/libpng.h
+++ b/src/unix/linux/x11/dl/libpng.h
@@ -4,71 +4,46 @@
 
 #pragma once
 
+#include <png.h>
+
 #include "sym.h"
 
 
 // Interface
-
-#define PNG_LIBPNG_VER_STRING "1.6.38"
-
-#define png_jmpbuf(png_ptr) \
-	(*png_set_longjmp_fn((png_ptr), longjmp, sizeof(jmp_buf)))
-
-#define PNG_COLOR_MASK_PALETTE 1
-#define PNG_COLOR_MASK_COLOR   2
-#define PNG_COLOR_MASK_ALPHA   4
-
-#define PNG_COLOR_TYPE_GRAY       0
-#define PNG_COLOR_TYPE_PALETTE    (PNG_COLOR_MASK_COLOR | PNG_COLOR_MASK_PALETTE)
-#define PNG_COLOR_TYPE_RGB        (PNG_COLOR_MASK_COLOR)
-#define PNG_COLOR_TYPE_RGB_ALPHA  (PNG_COLOR_MASK_COLOR | PNG_COLOR_MASK_ALPHA)
-#define PNG_COLOR_TYPE_GRAY_ALPHA (PNG_COLOR_MASK_ALPHA)
-
-#define PNG_FILLER_BEFORE 0
-#define PNG_FILLER_AFTER  1
-
-typedef unsigned int png_uint_32;
-typedef const char *png_const_charp;
-typedef void *png_voidp;
-
-typedef unsigned char png_byte;
-typedef png_byte *png_bytep;
-typedef const png_byte *png_const_bytep;
-
-typedef struct png_struct_def png_struct;
-typedef png_struct *png_structp;
-typedef png_struct *png_structrp;
-typedef const png_struct *png_const_structrp;
-typedef png_struct **png_structpp;
-
-typedef struct png_info_def png_info;
-typedef png_info *png_infop;
-typedef png_info *png_inforp;
-typedef const png_info *png_const_inforp;
-typedef png_info **png_infopp;
-
-typedef void (*png_error_ptr)(png_structp, png_const_charp);
-typedef void (*png_rw_ptr)(png_structp, png_bytep, size_t);
-typedef void (*png_longjmp_ptr)(jmp_buf, int);
-
-static int (*png_sig_cmp)(png_const_bytep sig, size_t start, size_t num_to_check);
-static png_structp (*png_create_read_struct)(png_const_charp user_png_ver,
+static int (*png_sig_cmp_ptr)(png_const_bytep sig, size_t start, size_t num_to_check);
+static png_structp (*png_create_read_struct_ptr)(png_const_charp user_png_ver,
 	png_voidp error_ptr, png_error_ptr error_fn, png_error_ptr warn_fn);
-void (*png_destroy_read_struct)(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr,
+void (*png_destroy_read_struct_ptr)(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr,
 	png_infopp end_info_ptr_ptr);
-static png_infop (*png_create_info_struct)(png_const_structrp png_ptr);
-void (*png_destroy_info_struct)(png_const_structrp png_ptr, png_infopp info_ptr_ptr);
-static void (*png_set_read_fn)(png_structrp png_ptr, png_voidp io_ptr, png_rw_ptr read_data_fn);
-static png_voidp (*png_get_io_ptr)(png_const_structrp png_ptr);
-static void (*png_set_sig_bytes)(png_structrp png_ptr, int num_bytes);
-static void (*png_read_info)(png_structrp png_ptr, png_inforp info_ptr);
-static png_uint_32 (*png_get_IHDR)(png_structp png_ptr, png_infop info_ptr, png_uint_32 *width, png_uint_32 *height,
+static png_infop (*png_create_info_struct_ptr)(png_const_structrp png_ptr);
+void (*png_destroy_info_struct_ptr)(png_const_structrp png_ptr, png_infopp info_ptr_ptr);
+static void (*png_set_read_fn_ptr)(png_structrp png_ptr, png_voidp io_ptr, png_rw_ptr read_data_fn);
+static png_voidp (*png_get_io_ptr_ptr)(png_const_structrp png_ptr);
+static void (*png_set_sig_bytes_ptr)(png_structrp png_ptr, int num_bytes);
+static void (*png_read_info_ptr)(png_structrp png_ptr, png_inforp info_ptr);
+static png_uint_32 (*png_get_IHDR_ptr)(png_structp png_ptr, png_infop info_ptr, png_uint_32 *width, png_uint_32 *height,
 	int *bit_depth, int *color_type, int *interlace_method, int *compression_method, int *filter_method);
-static void (*png_set_add_alpha)(png_structp png_ptr, png_uint_32 filler, int flags);
-static int (*png_set_interlace_handling)(png_structrp png_ptr);
-static void (*png_read_update_info)(png_structrp png_ptr, png_inforp info_ptr);
-static void (*png_read_row)(png_structrp png_ptr, png_bytep row, png_bytep display_row);
-static jmp_buf *(*png_set_longjmp_fn)(png_structrp png_ptr, png_longjmp_ptr longjmp_fn, size_t jmp_buf_size);
+static void (*png_set_add_alpha_ptr)(png_structp png_ptr, png_uint_32 filler, int flags);
+static int (*png_set_interlace_handling_ptr)(png_structrp png_ptr);
+static void (*png_read_update_info_ptr)(png_structrp png_ptr, png_inforp info_ptr);
+static void (*png_read_row_ptr)(png_structrp png_ptr, png_bytep row, png_bytep display_row);
+static jmp_buf *(*png_set_longjmp_fn_ptr)(png_structrp png_ptr, png_longjmp_ptr longjmp_fn, size_t jmp_buf_size);
+
+#define png_sig_cmp png_sig_cmp_ptr
+#define png_create_read_struct png_create_read_struct_ptr
+#define png_destroy_read_struct png_destroy_read_struct_ptr
+#define png_create_info_struct png_create_info_struct_ptr
+#define png_destroy_info_struct png_destroy_info_struct_ptr
+#define png_set_read_fn png_set_read_fn_ptr
+#define png_get_io_ptr png_get_io_ptr_ptr
+#define png_set_sig_bytes png_set_sig_bytes_ptr
+#define png_read_info png_read_info_ptr
+#define png_get_IHDR png_get_IHDR_ptr
+#define png_set_add_alpha png_set_add_alpha_ptr
+#define png_set_interlace_handling png_set_interlace_handling_ptr
+#define png_read_update_info png_read_update_info_ptr
+#define png_read_row png_read_row_ptr
+#define png_set_longjmp_fn png_set_longjmp_fn_ptr
 
 
 // Runtime open
@@ -95,6 +70,12 @@ static bool libpng_global_init(void)
 		bool r = true;
 
 		LIBPNG_SO = MTY_SOLoad("libpng16.so.16");
+		if (!LIBPNG_SO)
+			LIBPNG_SO = MTY_SOLoad("libpng16.so");
+
+		if (!LIBPNG_SO)
+			LIBPNG_SO = MTY_SOLoad("libpng.so");
+
 		if (!LIBPNG_SO) {
 			r = false;
 			goto except;

--- a/src/unix/linux/x11/dl/libssl.h
+++ b/src/unix/linux/x11/dl/libssl.h
@@ -116,13 +116,16 @@ static MTY_Atomic32 LIBSSL_LOCK;
 static MTY_SO *LIBSSL_SO;
 static bool LIBSSL_INIT;
 
+static void libssl_global_destroy_lockfree(void)
+{
+	MTY_SOUnload(&LIBSSL_SO);
+	LIBSSL_INIT = false;
+}
+
 static void __attribute__((destructor)) libssl_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBSSL_LOCK);
-
-	MTY_SOUnload(&LIBSSL_SO);
-	LIBSSL_INIT = false;
-
+	libssl_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBSSL_LOCK);
 }
 
@@ -220,7 +223,7 @@ static bool libssl_global_init(void)
 		except:
 
 		if (!r)
-			libssl_global_destroy();
+			libssl_global_destroy_lockfree();
 
 		LIBSSL_INIT = r;
 	}

--- a/src/unix/linux/x11/dl/libssl.h
+++ b/src/unix/linux/x11/dl/libssl.h
@@ -125,7 +125,9 @@ static void libssl_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libssl_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBSSL_LOCK);
+
 	libssl_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBSSL_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libudev.h
+++ b/src/unix/linux/x11/dl/libudev.h
@@ -44,13 +44,16 @@ static MTY_Atomic32 LIBUDEV_LOCK;
 static MTY_SO *LIBUDEV_SO;
 static bool LIBUDEV_INIT;
 
+static void libudev_global_destroy_lockfree(void)
+{
+	MTY_SOUnload(&LIBUDEV_SO);
+	LIBUDEV_INIT = false;
+}
+
 static void __attribute__((destructor)) libudev_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBUDEV_LOCK);
-
-	MTY_SOUnload(&LIBUDEV_SO);
-	LIBUDEV_INIT = false;
-
+	libudev_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBUDEV_LOCK);
 }
 
@@ -91,7 +94,7 @@ static bool libudev_global_init(void)
 		except:
 
 		if (!r)
-			libudev_global_destroy();
+			libudev_global_destroy_lockfree();
 
 		LIBUDEV_INIT = r;
 	}

--- a/src/unix/linux/x11/dl/libudev.h
+++ b/src/unix/linux/x11/dl/libudev.h
@@ -53,7 +53,9 @@ static void libudev_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libudev_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBUDEV_LOCK);
+
 	libudev_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBUDEV_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libx11.c
+++ b/src/unix/linux/x11/dl/libx11.c
@@ -147,7 +147,9 @@ static void libX11_global_destroy_lockfree(void)
 static void __attribute__((destructor)) libX11_global_destroy(void)
 {
 	MTY_GlobalLock(&LIBX11_LOCK);
+
 	libX11_global_destroy_lockfree();
+
 	MTY_GlobalUnlock(&LIBX11_LOCK);
 }
 

--- a/src/unix/linux/x11/dl/libx11.c
+++ b/src/unix/linux/x11/dl/libx11.c
@@ -134,17 +134,20 @@ static MTY_SO *LIBXCURSOR_SO;
 static MTY_SO *LIBGL_SO;
 static bool LIBX11_INIT;
 
-static void __attribute__((destructor)) libX11_global_destroy(void)
+static void libX11_global_destroy_lockfree(void)
 {
-	MTY_GlobalLock(&LIBX11_LOCK);
-
 	MTY_SOUnload(&LIBGL_SO);
 	MTY_SOUnload(&LIBXCURSOR_SO);
 	MTY_SOUnload(&LIBXI_SO);
 	MTY_SOUnload(&LIBXFIXES_SO);
 	MTY_SOUnload(&LIBX11_SO);
 	LIBX11_INIT = false;
+}
 
+static void __attribute__((destructor)) libX11_global_destroy(void)
+{
+	MTY_GlobalLock(&LIBX11_LOCK);
+	libX11_global_destroy_lockfree();
 	MTY_GlobalUnlock(&LIBX11_LOCK);
 }
 
@@ -252,7 +255,7 @@ static bool libX11_global_init(void)
 		except:
 
 		if (!r)
-			libX11_global_destroy();
+			libX11_global_destroy_lockfree();
 
 		LIBX11_INIT = r;
 	}


### PR DESCRIPTION
1. Failed dynamic lib loading would cause a deadlock, terminating the app (Resolved)
2. Custom headers for libjpeg, libpng, and libasound, are not a great idea (Now uses installed headers)

I would've done the same for libcrypto, libcurl, libssl, libudev, and libx11, but those appear more involved, and seem to be more consistent between versions. It would take much more time to extend this work to those.

Install `libasound2-dev`, `libjpeg-dev`, and `libpng-dev`, to build MTY on Linux