### PR TITLE
Android tweaks

### DIFF
--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -213,23 +213,15 @@ public class Matoya extends SurfaceView implements
 	}
 
 	boolean keyEvent(int keyCode, KeyEvent event, boolean down) {
-		// For mixed source InputDevice, we prefer Keyboard event handling to Gamepad event handling
-		if (isKeyboardEvent(event)) {
-			int uc = event.getUnicodeChar();
-
-			return app_key(down, keyCode, uc != 0 ? String.format("%c", uc) : null,
-				event.getMetaState(), event.getDeviceId() <= 0);
-		}
 		// Button events fire here (sometimes dpad)
-		if (isGamepadEvent(event)) {
+		if (isGamepadEvent(event))
 			app_button(event.getDeviceId(), down, keyCode);
 
 		// Prevents back buttons etc. from being generated from mice
-		} else if (!isMouseEvent(event)) {
+		if (isKeyboardEvent(event) && !isMouseEvent(event)) {
 			int uc = event.getUnicodeChar();
-
-			return app_key(down, keyCode, uc != 0 ? String.format("%c", uc) : null,
-				event.getMetaState(), event.getDeviceId() <= 0);
+			String text = uc != 0 ? String.format("%c", uc) : null;
+			return app_key(down, keyCode, text, event.getMetaState(), event.getDeviceId() <= 0) || isGamepadEvent(event);
 		}
 
 		return true;

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -656,14 +656,11 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1axis(JNIEnv *env, jobje
 	c->axes[MTY_CAXIS_TRIGGER_L].value = lrint(lT * (float) UINT8_MAX);
 	c->axes[MTY_CAXIS_TRIGGER_R].value = lrint(rT * (float) UINT8_MAX);
 
-	// Xbox Series X hack
-	if (c->vid == 0x045E && c->pid == 0x0B13) {
-		if (c->axes[MTY_CAXIS_TRIGGER_L].value == 0)
-			c->axes[MTY_CAXIS_TRIGGER_L].value = lrint(lTalt * (float) UINT8_MAX);
+	if (c->axes[MTY_CAXIS_TRIGGER_L].value == 0)
+		c->axes[MTY_CAXIS_TRIGGER_L].value = lrint(lTalt * (float) UINT8_MAX);
 
-		if (c->axes[MTY_CAXIS_TRIGGER_R].value == 0)
-			c->axes[MTY_CAXIS_TRIGGER_R].value = lrint(rTalt * (float) UINT8_MAX);
-	}
+	if (c->axes[MTY_CAXIS_TRIGGER_R].value == 0)
+		c->axes[MTY_CAXIS_TRIGGER_R].value = lrint(rTalt * (float) UINT8_MAX);
 
 	c->buttons[MTY_CBUTTON_DPAD_UP] = hatY == -1.0f;
 	c->buttons[MTY_CBUTTON_DPAD_DOWN] = hatY == 1.0f;


### PR DESCRIPTION
This PR will contain a variety of small adjustments for the Android application, one commit per fix.

## [No priority between keyboard and gamepad, let's try both](https://github.com/parsec-cloud/libmatoya/pull/111/commits/ef02fb1d453ef7506ba4fafd51182d1e6e73d859)
#87 introduced issues with Android gamepad support. Some events are (incorrectly?) flagged as both keyboard ans gamepad, and prioritizing one kind over the other make some events be discarded (e.g. the Razer Kishi v2 reports A/B/X/Y as such). Instead of trying to choose between those two kinds, it should be safe to always try both: in case of keyboard event, the gamepad event handler won't do anything, and in case of gamepad handler, the keyboard handler won't do anything.

## [Remove Xbox guard around trigger axes](https://github.com/parsec-cloud/libmatoya/pull/111/commits/90fb9e73a2f137b9dfb26cf5e5b1320093d42250)
Kishi's triggers were not functioning at all because they weren't reported as actual triggers but as 'gas' and 'brake'. Turns out that specificity was already taken care of, but only for the Xbox Series X gamepad. Removing that guard seems safe and fixes that issue.