### PR TITLE
Extend MTY_RestartProcess so it can work on Windows

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3377,14 +3377,11 @@ MTY_StartInProcess(const char *path, const char * const *argv, const char *dir);
 /// @details For more information, see `execv` from the C standard library.
 /// @param argv Arguments to set up a call to `execv`. This is an array of strings
 ///   that must have its last element set to NULL.
-/// @param dir The working directory to set. May be NULL to use the current working directory
 /// @returns On success this function does not return, otherwise it returns false.
 ///   Call MTY_GetLog for details.
 //- #support Windows macOS Linux
 MTY_EXPORT bool
-MTY_RestartProcess(const char * const *argv, const char *dir);
-
-
+MTY_RestartProcess(char * const *argv);
 
 /// @brief Set a function to be called just before abnormal termination.
 /// @details This will attempt to hook `SIGKILL`, `SIGTERM`, and any Windows

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3328,13 +3328,16 @@ MTY_GetProcessDir(void);
 
 /// @brief Restart the current process.
 /// @details For more information, see `execv` from the C standard library.
+/// @param path Full path to the current process executable, or another executable to execv.
+///   May be set to `NULL` to restart the current process.
 /// @param argv Arguments to set up a call to `execv`. This is an array of strings
 ///   that must have its last element set to NULL.
+/// @param dir The working directory to set. May be NULL to use the current working directory
 /// @returns On success this function does not return, otherwise it returns false.
 ///   Call MTY_GetLog for details.
 //- #support Windows macOS Linux
 MTY_EXPORT bool
-MTY_RestartProcess(char * const *argv);
+MTY_RestartProcess(const char *path, const char * const *argv, const char *dir);
 
 /// @brief Set a function to be called just before abnormal termination.
 /// @details This will attempt to hook `SIGKILL`, `SIGTERM`, and any Windows

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3360,9 +3360,9 @@ MTY_GetProcessPath(void);
 MTY_EXPORT const char *
 MTY_GetProcessDir(void);
 
-/// @brief Restart the current process.
+/// @brief Restart the current process into a specific binary.
 /// @details For more information, see `execv` from the C standard library.
-/// @param path Full path to the current process executable, or another executable to execv.
+/// @param path Full path to an executable to execv.
 ///   May be set to `NULL` to restart the current process.
 /// @param argv Arguments to set up a call to `execv`. This is an array of strings
 ///   that must have its last element set to NULL.
@@ -3371,7 +3371,20 @@ MTY_GetProcessDir(void);
 ///   Call MTY_GetLog for details.
 //- #support Windows macOS Linux
 MTY_EXPORT bool
-MTY_RestartProcess(const char *path, const char * const *argv, const char *dir);
+MTY_StartInProcess(const char *path, const char * const *argv, const char *dir);
+
+/// @brief Restart the current process.
+/// @details For more information, see `execv` from the C standard library.
+/// @param argv Arguments to set up a call to `execv`. This is an array of strings
+///   that must have its last element set to NULL.
+/// @param dir The working directory to set. May be NULL to use the current working directory
+/// @returns On success this function does not return, otherwise it returns false.
+///   Call MTY_GetLog for details.
+//- #support Windows macOS Linux
+MTY_EXPORT bool
+MTY_RestartProcess(const char * const *argv, const char *dir);
+
+
 
 /// @brief Set a function to be called just before abnormal termination.
 /// @details This will attempt to hook `SIGKILL`, `SIGTERM`, and any Windows

--- a/src/unix/apple/iphoneos/system.m
+++ b/src/unix/apple/iphoneos/system.m
@@ -33,7 +33,7 @@ bool MTY_StartInProcess(const char *path, const char * const *argv, const char *
 	return false;
 }
 
-bool MTY_RestartProcess(const char * const *argv, const char *dir)
+bool MTY_RestartProcess(char * const *argv)
 {
-	return MTY_StartInProcess(NULL, argv, dir);
+	return MTY_StartInProcess(NULL, argv, NULL);
 }

--- a/src/unix/apple/iphoneos/system.m
+++ b/src/unix/apple/iphoneos/system.m
@@ -28,7 +28,12 @@ const char *MTY_GetProcessPath(void)
 	return "/app";
 }
 
-bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
+bool MTY_StartInProcess(const char *path, const char * const *argv, const char *dir)
 {
 	return false;
+}
+
+bool MTY_RestartProcess(const char * const *argv, const char *dir)
+{
+	return MTY_StartInProcess(NULL, argv, dir);
 }

--- a/src/unix/apple/iphoneos/system.m
+++ b/src/unix/apple/iphoneos/system.m
@@ -28,7 +28,7 @@ const char *MTY_GetProcessPath(void)
 	return "/app";
 }
 
-bool MTY_RestartProcess(char * const *argv)
+bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
 {
 	return false;
 }

--- a/src/unix/apple/macosx/system.m
+++ b/src/unix/apple/macosx/system.m
@@ -58,7 +58,7 @@ const char *MTY_GetProcessPath(void)
 	return mty_tlocal_strcpy(tmp);
 }
 
-bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
+bool MTY_StartInProcess(const char *path, const char * const *argv, const char *dir)
 {
 	if (dir) {
 		if (chdir(dir) == -1) {
@@ -74,6 +74,11 @@ bool MTY_RestartProcess(const char *path, const char * const *argv, const char *
 	MTY_Log("'execv' failed with errno %d", errno);
 
 	return false;
+}
+
+bool MTY_RestartProcess(const char * const *argv, const char *dir)
+{
+	return MTY_StartInProcess(NULL, argv, dir);
 }
 
 void *MTY_GetJNIEnv(void)

--- a/src/unix/apple/macosx/system.m
+++ b/src/unix/apple/macosx/system.m
@@ -58,9 +58,19 @@ const char *MTY_GetProcessPath(void)
 	return mty_tlocal_strcpy(tmp);
 }
 
-bool MTY_RestartProcess(char * const *argv)
+bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
 {
-	execv(MTY_GetProcessPath(), argv);
+	if (dir) {
+		if (chdir(dir) == -1) {
+			MTY_Log("chdir failed with errno %d", errno);
+			return false;
+		}
+	}
+
+	if (!path)
+		path = MTY_GetProcessPath();
+
+	execv(path, argv);
 	MTY_Log("'execv' failed with errno %d", errno);
 
 	return false;

--- a/src/unix/apple/macosx/system.m
+++ b/src/unix/apple/macosx/system.m
@@ -76,9 +76,9 @@ bool MTY_StartInProcess(const char *path, const char * const *argv, const char *
 	return false;
 }
 
-bool MTY_RestartProcess(const char * const *argv, const char *dir)
+bool MTY_RestartProcess(char * const *argv)
 {
-	return MTY_StartInProcess(NULL, argv, dir);
+	return MTY_StartInProcess(NULL, argv, NULL);
 }
 
 void *MTY_GetJNIEnv(void)

--- a/src/unix/linux/android/system.c
+++ b/src/unix/linux/android/system.c
@@ -51,9 +51,14 @@ const char *MTY_GetProcessPath(void)
 	return "/app";
 }
 
-bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
+bool MTY_StartInProcess(const char *path, const char * const *argv, const char *dir)
 {
 	return false;
+}
+
+bool MTY_RestartProcess(const char * const *argv, const char *dir)
+{
+	return MTY_StartInProcess(NULL, argv, dir);
 }
 
 

--- a/src/unix/linux/android/system.c
+++ b/src/unix/linux/android/system.c
@@ -56,9 +56,9 @@ bool MTY_StartInProcess(const char *path, const char * const *argv, const char *
 	return false;
 }
 
-bool MTY_RestartProcess(const char * const *argv, const char *dir)
+bool MTY_RestartProcess(char * const *argv)
 {
-	return MTY_StartInProcess(NULL, argv, dir);
+	return MTY_StartInProcess(NULL, argv, NULL);
 }
 
 

--- a/src/unix/linux/android/system.c
+++ b/src/unix/linux/android/system.c
@@ -51,7 +51,7 @@ const char *MTY_GetProcessPath(void)
 	return "/app";
 }
 
-bool MTY_RestartProcess(char * const *argv)
+bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
 {
 	return false;
 }

--- a/src/unix/linux/x11/system.c
+++ b/src/unix/linux/x11/system.c
@@ -52,7 +52,7 @@ const char *MTY_GetProcessPath(void)
 	return mty_tlocal_strcpy(tmp);
 }
 
-bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
+bool MTY_StartInProcess(const char *path, const char * const *argv, const char *dir)
 {
 	if (dir) {
 		if (chdir(dir) == -1) {
@@ -68,6 +68,11 @@ bool MTY_RestartProcess(const char *path, const char * const *argv, const char *
 	MTY_Log("'execv' failed with errno %d", errno);
 
 	return false;
+}
+
+bool MTY_RestartProcess(const char * const *argv, const char *dir)
+{
+	return MTY_StartInProcess(NULL, argv, dir);
 }
 
 void *MTY_GetJNIEnv(void)

--- a/src/unix/linux/x11/system.c
+++ b/src/unix/linux/x11/system.c
@@ -52,9 +52,19 @@ const char *MTY_GetProcessPath(void)
 	return mty_tlocal_strcpy(tmp);
 }
 
-bool MTY_RestartProcess(char * const *argv)
+bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
 {
-	execv(MTY_GetProcessPath(), argv);
+	if (dir) {
+		if (chdir(dir) == -1) {
+			MTY_Log("'chdir' failed with errno %d", errno);
+			return false;
+		}
+	}
+
+	if (!path)
+		path = MTY_GetProcessPath();
+
+	execv(path, argv);
 	MTY_Log("'execv' failed with errno %d", errno);
 
 	return false;

--- a/src/unix/linux/x11/system.c
+++ b/src/unix/linux/x11/system.c
@@ -70,9 +70,9 @@ bool MTY_StartInProcess(const char *path, const char * const *argv, const char *
 	return false;
 }
 
-bool MTY_RestartProcess(const char * const *argv, const char *dir)
+bool MTY_RestartProcess(char * const *argv)
 {
-	return MTY_StartInProcess(NULL, argv, dir);
+	return MTY_StartInProcess(NULL, argv, NULL);
 }
 
 void *MTY_GetJNIEnv(void)

--- a/src/unix/web/system.c
+++ b/src/unix/web/system.c
@@ -81,9 +81,9 @@ bool MTY_StartInProcess(const char *path, const char * const *argv, const char *
 	return false;
 }
 
-bool MTY_RestartProcess(const char * const *argv, const char *dir)
+bool MTY_RestartProcess(char * const *argv)
 {
-	return MTY_StartInProcess(NULL, argv, dir);
+	return MTY_StartInProcess(NULL, argv, NULL);
 }
 
 void MTY_SetCrashFunc(MTY_CrashFunc func, void *opaque)

--- a/src/unix/web/system.c
+++ b/src/unix/web/system.c
@@ -76,7 +76,7 @@ const char *MTY_GetProcessPath(void)
 	return "/app";
 }
 
-bool MTY_RestartProcess(char * const *argv)
+bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
 {
 	return false;
 }

--- a/src/unix/web/system.c
+++ b/src/unix/web/system.c
@@ -76,9 +76,14 @@ const char *MTY_GetProcessPath(void)
 	return "/app";
 }
 
-bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
+bool MTY_StartInProcess(const char *path, const char * const *argv, const char *dir)
 {
 	return false;
+}
+
+bool MTY_RestartProcess(const char * const *argv, const char *dir)
+{
+	return MTY_StartInProcess(NULL, argv, dir);
 }
 
 void MTY_SetCrashFunc(MTY_CrashFunc func, void *opaque)

--- a/src/windows/systemw.c
+++ b/src/windows/systemw.c
@@ -160,27 +160,39 @@ const char *MTY_GetProcessPath(void)
 	return MTY_WideToMultiDL(tmp);
 }
 
-bool MTY_RestartProcess(char * const *argv)
+bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
 {
-	WCHAR *name = MTY_MultiToWideD(MTY_GetProcessPath());
-	WCHAR **argvn = NULL;
-
-	for (uint32_t x = 0; argv && argv[x]; x++) {
-		argvn = MTY_Realloc(argvn, x + 2, sizeof(char *));
-		argvn[x] = MTY_MultiToWideD(argv[x]);
-		argvn[x + 1] = NULL;
+	if (dir) {
+		WCHAR dirw[MAX_PATH] = {0};
+		MTY_MultiToWide(dir, dirw, MAX_PATH);
+		SetCurrentDirectory(dirw);
 	}
 
-	bool r = _wexecv(name, argvn);
+	WCHAR *pathw = MTY_MultiToWideD(path ? path : MTY_GetProcessPath());
+
+	// Rebuild argv with wide strings
+	size_t argc = 0;
+	for (; argv[argc]; argc++);
+
+	WCHAR **argvn = MTY_Alloc(argc + 1, sizeof(WCHAR *));
+	argvn[argc] = NULL;
+	for (uint32_t x = 0; x < argc; x++)
+		argvn[x] = MTY_MultiToWideD(argv[x]);
+
+	// flush and exec
+	_flushall();
+	_wexecv(pathw, argvn);
+
+	// Reaching here means exec failed. Clean up and free
 	MTY_Log("'_wexecv' failed with errno %d", errno);
 
 	for (uint32_t x = 0; argvn && argvn[x]; x++)
 		MTY_Free(argvn[x]);
 
 	MTY_Free(argvn);
-	MTY_Free(name);
+	MTY_Free(pathw);
 
-	return r;
+	return false;
 }
 
 static LONG WINAPI system_exception_handler(EXCEPTION_POINTERS *ex)

--- a/src/windows/systemw.c
+++ b/src/windows/systemw.c
@@ -160,7 +160,7 @@ const char *MTY_GetProcessPath(void)
 	return MTY_WideToMultiDL(tmp);
 }
 
-bool MTY_RestartProcess(const char *path, const char * const *argv, const char *dir)
+bool MTY_StartInProcess(const char *path, const char * const *argv, const char *dir)
 {
 	if (dir) {
 		WCHAR dirw[MAX_PATH] = {0};
@@ -193,6 +193,11 @@ bool MTY_RestartProcess(const char *path, const char * const *argv, const char *
 	MTY_Free(pathw);
 
 	return false;
+}
+
+bool MTY_RestartProcess(const char * const *argv, const char *dir)
+{
+	return MTY_StartInProcess(NULL, argv, dir);
 }
 
 static LONG WINAPI system_exception_handler(EXCEPTION_POINTERS *ex)

--- a/src/windows/systemw.c
+++ b/src/windows/systemw.c
@@ -195,9 +195,9 @@ bool MTY_StartInProcess(const char *path, const char * const *argv, const char *
 	return false;
 }
 
-bool MTY_RestartProcess(const char * const *argv, const char *dir)
+bool MTY_RestartProcess(char * const *argv)
 {
-	return MTY_StartInProcess(NULL, argv, dir);
+	return MTY_StartInProcess(NULL, argv, NULL);
 }
 
 static LONG WINAPI system_exception_handler(EXCEPTION_POINTERS *ex)


### PR DESCRIPTION
Due to some Windows things, we need the option to specify the actual executable to restart into, and its current working directory.