### PR TITLE
MTY_QueueFlush improvement

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -21,6 +21,7 @@ struct queue_slot {
 struct MTY_Queue {
 	size_t buf_size;
 	uint32_t len;
+	bool ptr_queue;
 
 	MTY_Waitable *pop_sync;
 	MTY_Mutex *push_mutex;
@@ -36,8 +37,10 @@ MTY_Queue *MTY_QueueCreate(uint32_t len, size_t bufSize)
 	ctx->len = len;
 	ctx->buf_size = bufSize;
 
-	if (ctx->buf_size < sizeof(void *))
+	if (ctx->buf_size < sizeof(void *)) {
+		ctx->ptr_queue = true;
 		ctx->buf_size = sizeof(void *);
+	}
 
 	ctx->pop_sync = MTY_WaitableCreate();
 	ctx->push_mutex = MTY_MutexCreate();

--- a/src/queue.c
+++ b/src/queue.c
@@ -208,6 +208,7 @@ bool MTY_QueuePopPtr(MTY_Queue *ctx, int32_t timeout, void **opaque, size_t *siz
 
 void MTY_QueueFlush(MTY_Queue *ctx, MTY_FreeFunc freeFunc)
 {
+	// Empty queue and call freeFunc on filled pointer slots
 	for (void *data = NULL; queue_pop(ctx, 0, false, (void **) &data, NULL);) {
 		struct queue_slot *slot = &ctx->slots[ctx->pop_pos];
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -219,4 +219,12 @@ void MTY_QueueFlush(MTY_Queue *ctx, MTY_FreeFunc freeFunc)
 
 		MTY_QueuePop(ctx);
 	}
+
+	for (uint32_t x = 0; x < ctx->len && !ctx->ptr_queue; x++) {
+		struct queue_slot *slot = &ctx->slots[x];
+		if (freeFunc)
+			freeFunc(slot->data);
+
+		memset(slot->data, 0, ctx->buf_size);
+	}
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -220,6 +220,7 @@ void MTY_QueueFlush(MTY_Queue *ctx, MTY_FreeFunc freeFunc)
 		MTY_QueuePop(ctx);
 	}
 
+	// Call freeFunc for all non-pointer slots and clear the slots
 	for (uint32_t x = 0; x < ctx->len && !ctx->ptr_queue; x++) {
 		struct queue_slot *slot = &ctx->slots[x];
 		if (freeFunc)


### PR DESCRIPTION
MTY_QueueFlush is unable to handle the need to free pointers within structs in non-pointer queues.

1. Marks whole queues as pointer queues based on their bufSize being 0 at creation, matching existing documentation
2. For non-pointer queues, calls the provided freeFunc in MTY_QueueFlush on _every_ slot before memset'ing the slot data to 0

memset is technically optional

Fixes an issue where persistent allocated data in non-pointer queues could not be free'd in any way.