### PR TITLE
Re-add no-op mouse fix for Windows

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -661,11 +661,17 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			break;
 		case WM_MOUSEMOVE:
 			if (!app->filter_move && !pen_active && (!app->relative || app_hwnd_active(hwnd))) {
+				evt.motion.x = GET_X_LPARAM(lparam);
+				evt.motion.y = GET_Y_LPARAM(lparam);
+
+				if (evt.motion.x = app->last_x && evt.motion.y == app->last_y)
+					break;
+
 				evt.type = MTY_EVENT_MOTION;
 				evt.motion.relative = false;
 				evt.motion.synth = false;
-				evt.motion.x = GET_X_LPARAM(lparam);
-				evt.motion.y = GET_Y_LPARAM(lparam);
+				app->last_x = evt.motion.x;
+				app->last_y = evt.motion.y;
 			}
 
 			app->filter_move = false;


### PR DESCRIPTION
[This PR](https://github.com/parsec-cloud/libmatoya/pull/17/files) was lost in some of our shuffling.

Stardock's Fences creates no-op mouse movements that cause Parsec clients to send mouse movement events to the host. 
If the client is supposed to just be watching, this can cause issues, as they're constantly (every ~1 second) warping the cursor to their cursor position.
If the client is one of multiple, with Exclusive Input mode enabled, the client can become the only non-owner guest able to use the mouse due to taking the input by accident with the no-op mouse events.
