### PR TITLE
[Web - Fix] WASM WebSocket Keepalive

### DIFF
--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -747,13 +747,13 @@ async function mty_ws_connect(url) {
 
 		ws.onopen = () => {
 			resolve(ws);
+			tm = setInterval(() => {ws.send('__ping__');}, 60000); // we've seen timeouts at the 10-minute mark,
+			                                                       // so a 60-second period should be more than enough
 		};
 
 		ws.onmessage = (ev) => {
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);
-			tm = setInterval(() => {ws.send('__ping__');}, 60000); // we've seen timeouts at the 10-minute mark,
-			                                                       // so a 60-second period should be more than enough
 		};
 	});
 }

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -732,13 +732,16 @@ async function mty_ws_connect(url) {
 		ws.closeCode = 0;
 		ws.msgs = [];
 
+		let tm = 0;
 		ws.onclose = (ev) => {
 			ws.closeCode = ev.code == 1005 ? 1000 : ev.code;
+			clearInterval(tm);
 			resolve(null);
 		};
 
 		ws.onerror = (err) => {
 			console.error(err);
+			clearInterval(tm);
 			resolve(null);
 		};
 
@@ -749,6 +752,7 @@ async function mty_ws_connect(url) {
 		ws.onmessage = (ev) => {
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);
+			tm = setInterval(() => {ws.send('__ping__');}, 60000); // Fake keepalive
 		};
 	});
 }

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -732,7 +732,7 @@ async function mty_ws_connect(url) {
 		ws.closeCode = 0;
 		ws.msgs = [];
 
-		let tm = 0;
+		let tm = 0; // JS clients can't do WebSocket ping/pong, so we do our own pseudo keepalive to prevent dropped connections
 		ws.onclose = (ev) => {
 			ws.closeCode = ev.code == 1005 ? 1000 : ev.code;
 			clearInterval(tm);
@@ -752,7 +752,8 @@ async function mty_ws_connect(url) {
 		ws.onmessage = (ev) => {
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);
-			tm = setInterval(() => {ws.send('__ping__');}, 60000); // Fake keepalive
+			tm = setInterval(() => {ws.send('__ping__');}, 60000); // we've seen timeouts at the 10-minute mark,
+			                                                       // so a 60-second period should be more than enough
 		};
 	});
 }


### PR DESCRIPTION
Sends a fake `__ping__` keepalive every 60 seconds.

Client-side javascript cannot send ping or pong command frames, this is a fake keepalive that prevents AWS and Cloudflare from considering the WebSocket to be idle and terminating it.