### PR TITLE
Fix focus events when using WebView on Windows

### DIFF
--- a/src/swebview.c
+++ b/src/swebview.c
@@ -591,6 +591,11 @@ void mty_webview_render(struct webview *ctx)
 	}
 }
 
+bool mty_webview_is_focussed(struct webview *ctx)
+{
+	return false;
+}
+
 bool mty_webview_is_steam(void)
 {
 	return true;

--- a/src/unix/apple/webview.m
+++ b/src/unix/apple/webview.m
@@ -353,6 +353,11 @@ void mty_webview_render(struct webview *ctx)
 {
 }
 
+bool mty_webview_is_focussed(struct webview *ctx)
+{
+	return false;
+}
+
 bool mty_webview_is_steam(void)
 {
 	return false;

--- a/src/unix/linux/android/webview.c
+++ b/src/unix/linux/android/webview.c
@@ -52,6 +52,11 @@ void mty_webview_render(struct webview *ctx)
 {
 }
 
+bool mty_webview_is_focussed(struct webview *ctx)
+{
+	return false;
+}
+
 bool mty_webview_is_steam(void)
 {
 	return false;

--- a/src/unix/linux/x11/webview.c
+++ b/src/unix/linux/x11/webview.c
@@ -52,6 +52,11 @@ void mty_webview_render(struct webview *ctx)
 {
 }
 
+bool mty_webview_is_focussed(struct webview *ctx)
+{
+	return false;
+}
+
 bool mty_webview_is_steam(void)
 {
 	return false;

--- a/src/unix/web/webview.c
+++ b/src/unix/web/webview.c
@@ -52,6 +52,11 @@ void mty_webview_render(struct webview *ctx)
 {
 }
 
+bool mty_webview_is_focussed(struct webview *ctx)
+{
+	return false;
+}
+
 bool mty_webview_is_steam(void)
 {
 	return false;

--- a/src/webview.h
+++ b/src/webview.h
@@ -24,4 +24,5 @@ void mty_webview_set_input_passthrough(struct webview *ctx, bool passthrough);
 bool mty_webview_event(struct webview *ctx, MTY_Event *evt);
 void mty_webview_run(struct webview *ctx);
 void mty_webview_render(struct webview *ctx);
+bool mty_webview_is_focussed(struct webview *ctx);
 bool mty_webview_is_steam(void);

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -27,6 +27,7 @@ struct window {
 	MTY_Frame frame;
 	HWND hwnd;
 	bool was_zoomed;
+	bool focussed;
 	uint32_t min_width;
 	uint32_t min_height;
 	RAWINPUT *ri;
@@ -627,8 +628,14 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 		}
 		case WM_SETFOCUS:
 		case WM_KILLFOCUS:
+			// If WebView2 is visible, only the WebView2 focus state is relevant.
+			// This comparison lets us ignore the original window focus state.
+			bool webview_visible = mty_webview_is_visible(ctx->cmn.webview);
+			if (webview_visible && (ctx->focussed != mty_webview_is_focussed(ctx->cmn.webview)))
+				break;
+
 			evt.type = MTY_EVENT_FOCUS;
-			evt.focus = msg == WM_SETFOCUS || mty_webview_is_focussed(ctx->cmn.webview);
+			ctx->focussed = evt.focus = (msg == WM_SETFOCUS);
 			app->state++;
 			break;
 		case WM_QUERYENDSESSION:

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -628,7 +628,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 		case WM_SETFOCUS:
 		case WM_KILLFOCUS:
 			evt.type = MTY_EVENT_FOCUS;
-			evt.focus = msg == WM_SETFOCUS;
+			evt.focus = msg == WM_SETFOCUS || mty_webview_is_focussed(ctx->cmn.webview);
 			app->state++;
 			break;
 		case WM_QUERYENDSESSION:

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -2006,7 +2006,9 @@ bool MTY_WindowIsActive(MTY_App *app, MTY_Window window)
 	if (!ctx)
 		return false;
 
-	return app_hwnd_active(ctx->hwnd);
+	struct window_common *cmn = mty_window_get_common(app, window);
+
+	return app_hwnd_active(ctx->hwnd) || mty_webview_is_focussed(cmn->webview);
 }
 
 void MTY_WindowActivate(MTY_App *app, MTY_Window window, bool active)

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -2017,8 +2017,9 @@ bool MTY_WindowIsActive(MTY_App *app, MTY_Window window)
 		return false;
 
 	struct window_common *cmn = mty_window_get_common(app, window);
+	bool webview_active = cmn && mty_webview_is_focussed(cmn->webview);
 
-	return app_hwnd_active(ctx->hwnd) || mty_webview_is_focussed(cmn->webview);
+	return app_hwnd_active(ctx->hwnd) || webview_active;
 }
 
 void MTY_WindowActivate(MTY_App *app, MTY_Window window, bool active)

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -102,6 +102,7 @@ static HRESULT STDMETHODCALLTYPE h3_Invoke_GotFocus(ICoreWebView2FocusChangedEve
 	struct webview *ctx = handler->opaque;
 
 	ctx->focussed = true;
+	PostMessage(MTY_WindowGetNative(ctx->app, ctx->window), WM_SETFOCUS, 0, 0);
 
 	return S_OK;
 }
@@ -113,6 +114,7 @@ static HRESULT STDMETHODCALLTYPE h3_Invoke_LostFocus(ICoreWebView2FocusChangedEv
 	struct webview *ctx = handler->opaque;
 
 	ctx->focussed = false;
+	PostMessage(MTY_WindowGetNative(ctx->app, ctx->window), WM_KILLFOCUS, 0, 0);
 
 	return S_OK;
 }
@@ -618,7 +620,7 @@ void mty_webview_show(struct webview *ctx, bool show)
 
 bool mty_webview_is_visible(struct webview *ctx)
 {
-	if (!ctx->controller)
+	if (!ctx || !ctx->controller)
 		return false;
 
 	BOOL visible = FALSE;

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -52,6 +52,7 @@ struct webview {
 	bool url;
 	bool debug;
 	bool passthrough;
+	bool focussed;
 	bool ready;
 };
 
@@ -599,6 +600,11 @@ void mty_webview_run(struct webview *ctx)
 
 void mty_webview_render(struct webview *ctx)
 {
+}
+
+bool mty_webview_is_focussed(struct webview *ctx)
+{
+	return ctx->focussed;
 }
 
 bool mty_webview_is_steam(void)

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -96,7 +96,7 @@ static HRESULT STDMETHODCALLTYPE h3_QueryInterface(void *This,
 }
 
 static HRESULT STDMETHODCALLTYPE h3_Invoke_GotFocus(ICoreWebView2FocusChangedEventHandler *This,
-	ICoreWebView2 *sender, IUnknown *args)
+	ICoreWebView2Controller *sender, IUnknown *args)
 {
 	struct webview_handler3 *handler = (struct webview_handler3 *) This;
 	struct webview *ctx = handler->opaque;
@@ -107,7 +107,7 @@ static HRESULT STDMETHODCALLTYPE h3_Invoke_GotFocus(ICoreWebView2FocusChangedEve
 }
 
 static HRESULT STDMETHODCALLTYPE h3_Invoke_LostFocus(ICoreWebView2FocusChangedEventHandler *This,
-	ICoreWebView2 *sender, IUnknown *args)
+	ICoreWebView2Controller *sender, IUnknown *args)
 {
 	struct webview_handler3 *handler = (struct webview_handler3 *) This;
 	struct webview *ctx = handler->opaque;
@@ -258,6 +258,11 @@ static HRESULT STDMETHODCALLTYPE h1_Invoke(ICoreWebView2CreateCoreWebView2Contro
 	ICoreWebView2Settings_put_AreDefaultContextMenusEnabled(settings, ctx->debug);
 	ICoreWebView2Settings_put_IsZoomControlEnabled(settings, FALSE);
 	ICoreWebView2Settings_Release(settings);
+
+	ICoreWebView2Controller2_add_GotFocus(ctx->controller,
+		(ICoreWebView2FocusChangedEventHandler *) &ctx->handler3, NULL);
+	ICoreWebView2Controller2_add_LostFocus(ctx->controller,
+		(ICoreWebView2FocusChangedEventHandler *) &ctx->handler4, NULL);
 
 	EventRegistrationToken token = {0};
 	ICoreWebView2_add_WebMessageReceived(ctx->webview,
@@ -665,7 +670,7 @@ void mty_webview_render(struct webview *ctx)
 
 bool mty_webview_is_focussed(struct webview *ctx)
 {
-	return ctx->focussed;
+	return ctx && ctx->focussed;
 }
 
 bool mty_webview_is_steam(void)

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -102,7 +102,8 @@ static HRESULT STDMETHODCALLTYPE h3_Invoke_GotFocus(ICoreWebView2FocusChangedEve
 	struct webview *ctx = handler->opaque;
 
 	ctx->focussed = true;
-	PostMessage(MTY_WindowGetNative(ctx->app, ctx->window), WM_SETFOCUS, 0, 0);
+	if (mty_webview_is_visible(ctx))
+		PostMessage(MTY_WindowGetNative(ctx->app, ctx->window), WM_SETFOCUS, 0, 0);
 
 	return S_OK;
 }
@@ -114,7 +115,8 @@ static HRESULT STDMETHODCALLTYPE h3_Invoke_LostFocus(ICoreWebView2FocusChangedEv
 	struct webview *ctx = handler->opaque;
 
 	ctx->focussed = false;
-	PostMessage(MTY_WindowGetNative(ctx->app, ctx->window), WM_KILLFOCUS, 0, 0);
+	if (mty_webview_is_visible(ctx))
+		PostMessage(MTY_WindowGetNative(ctx->app, ctx->window), WM_KILLFOCUS, 0, 0);
 
 	return S_OK;
 }


### PR DESCRIPTION
1. Maintains focus state on Windows WebView via GotFocus and LostFocus handlers
2. Posts Windows WebView focus events to the parent window, to act on during normal event handling
3. Coalesces the normal and WebView focus events in a way that accounts for showing and hiding the webview during runtime

In testing, this properly triggers focus events in all but one case.

The one remaining problem case is minor; When making the webview visible, the parent window loses focus before the WebView's own focus event comes through, causing a very _very_ small period where the application is considered unfocussed