### PR TITLE
Function to check if WebView is actually available

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -458,6 +458,11 @@ bool MTY_WebViewIsSteam(void)
 	return mty_webview_is_steam();
 }
 
+bool MTY_WebViewIsAvailable(void)
+{
+	return mty_webview_is_available();
+}
+
 
 // Window sizing
 

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -1370,6 +1370,13 @@ MTY_WebViewSetInputPassthrough(MTY_App *app, MTY_Window window, bool passthrough
 MTY_EXPORT bool
 MTY_WebViewIsSteam(void);
 
+/// @brief Check if the WebView is available on the current platform.
+/// @details The function returns true if the platform supports WebView, AND has the necessary
+///   dependencies to create a WebView. For example, on Windows, WebView is only available on
+///   Windows 10 and later, and the WebView2 runtime must be installed.
+MTY_EXPORT bool
+MTY_WebViewIsAvailable(void);
+
 /// @brief Fill an MTY_Frame taking the current display settings into account.
 /// @details The returned MTY_Frame can be passed directly to MTY_WindowCreate or
 ///   MTY_WindowSetFrame.

--- a/src/swebview.c
+++ b/src/swebview.c
@@ -600,3 +600,8 @@ bool mty_webview_is_steam(void)
 {
 	return true;
 }
+
+bool mty_webview_is_available(void)
+{
+	return true;
+}

--- a/src/unix/apple/webview.m
+++ b/src/unix/apple/webview.m
@@ -362,3 +362,9 @@ bool mty_webview_is_steam(void)
 {
 	return false;
 }
+
+
+bool mty_webview_is_available(void)
+{
+	return mty_webview_supported();
+}

--- a/src/unix/linux/android/webview.c
+++ b/src/unix/linux/android/webview.c
@@ -61,3 +61,8 @@ bool mty_webview_is_steam(void)
 {
 	return false;
 }
+
+bool mty_webview_is_available(void)
+{
+	return false;
+}

--- a/src/unix/linux/x11/webview.c
+++ b/src/unix/linux/x11/webview.c
@@ -61,3 +61,8 @@ bool mty_webview_is_steam(void)
 {
 	return false;
 }
+
+bool mty_webview_is_available(void)
+{
+	return false;
+}

--- a/src/unix/web/webview.c
+++ b/src/unix/web/webview.c
@@ -61,3 +61,8 @@ bool mty_webview_is_steam(void)
 {
 	return false;
 }
+
+bool mty_webview_is_available(void)
+{
+	return false;
+}

--- a/src/webview.h
+++ b/src/webview.h
@@ -26,3 +26,4 @@ void mty_webview_run(struct webview *ctx);
 void mty_webview_render(struct webview *ctx);
 bool mty_webview_is_focussed(struct webview *ctx);
 bool mty_webview_is_steam(void);
+bool mty_webview_is_available(void);

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -681,3 +681,14 @@ bool mty_webview_is_steam(void)
 {
 	return false;
 }
+
+bool mty_webview_is_available(void)
+{
+	MTY_SO *webview = webview_load_dll();
+	if (webview) {
+		MTY_SOUnload(&webview);
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
An OS version check by itself isn't enough for Windows, which also needs to have the WebView2 runtime installed.

Adds `MTY_WebViewIsAvailable`, which checks for all requirements.
Currently this checks macOS for its version, and Windows for the presence of the WebView2 runtime.