### PR TITLE
[All - Fix] Improved threading safety, notably on macOS

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2827,6 +2827,10 @@ MTY_ThreadPoolDetach(MTY_ThreadPool *ctx, uint32_t index, MTY_AnonFunc detach);
 MTY_EXPORT MTY_Async
 MTY_ThreadPoolPoll(MTY_ThreadPool *ctx, uint32_t index, void **opaque);
 
+/// @brief Force code above barrier to complete, before code below barrier begins.
+MTY_EXPORT void
+MTY_MemoryBarrier();
+
 /// @brief Set a 32-bit integer atomically.
 /// @details All atomic operations in libmatoya create a full memory barrier.
 /// @param atomic An MTY_Atomic32.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2827,10 +2827,6 @@ MTY_ThreadPoolDetach(MTY_ThreadPool *ctx, uint32_t index, MTY_AnonFunc detach);
 MTY_EXPORT MTY_Async
 MTY_ThreadPoolPoll(MTY_ThreadPool *ctx, uint32_t index, void **opaque);
 
-/// @brief Force code above barrier to complete, before code below barrier begins.
-MTY_EXPORT void
-MTY_MemoryBarrier();
-
 /// @brief Set a 32-bit integer atomically.
 /// @details All atomic operations in libmatoya create a full memory barrier.
 /// @param atomic An MTY_Atomic32.

--- a/src/thread.c
+++ b/src/thread.c
@@ -200,7 +200,7 @@ bool MTY_WaitableWait(MTY_Waitable *ctx, int32_t timeout)
 void MTY_WaitableSignal(MTY_Waitable *ctx)
 {
 	if (!ctx)
-		return false;
+		return;
 
 	MTY_MutexLock(ctx->mutex);
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -250,6 +250,7 @@ void MTY_ThreadPoolDestroy(MTY_ThreadPool **pool, MTY_AnonFunc detach)
 		return;
 
 	MTY_ThreadPool *ctx = *pool;
+	*pool = NULL;
 
 	for (uint32_t x = 0; x < ctx->num; x++) {
 		MTY_ThreadPoolDetach(ctx, x, detach);
@@ -262,7 +263,6 @@ void MTY_ThreadPoolDestroy(MTY_ThreadPool **pool, MTY_AnonFunc detach)
 
 	MTY_Free(ctx->ti);
 	MTY_Free(ctx);
-	*pool = NULL;
 }
 
 static void *thread_pool_func(void *opaque)
@@ -288,6 +288,9 @@ static void *thread_pool_func(void *opaque)
 
 uint32_t MTY_ThreadPoolDispatch(MTY_ThreadPool *ctx, MTY_AnonFunc func, void *opaque)
 {
+	if (!ctx)
+		return 0;
+
 	uint32_t index = 0;
 
 	for (uint32_t x = 1; x < ctx->num && index == 0; x++) {
@@ -317,6 +320,9 @@ uint32_t MTY_ThreadPoolDispatch(MTY_ThreadPool *ctx, MTY_AnonFunc func, void *op
 
 void MTY_ThreadPoolDetach(MTY_ThreadPool *ctx, uint32_t index, MTY_AnonFunc detach)
 {
+	if (!ctx)
+		return;
+
 	struct thread_info *ti = &ctx->ti[index];
 
 	MTY_MutexLock(ti->m);
@@ -336,6 +342,9 @@ void MTY_ThreadPoolDetach(MTY_ThreadPool *ctx, uint32_t index, MTY_AnonFunc deta
 
 MTY_Async MTY_ThreadPoolPoll(MTY_ThreadPool *ctx, uint32_t index, void **opaque)
 {
+	if (!ctx)
+		return MTY_ASYNC_ERROR;
+
 	struct thread_info *ti = &ctx->ti[index];
 
 	MTY_MutexLock(ti->m);

--- a/src/thread.c
+++ b/src/thread.c
@@ -56,6 +56,7 @@ void MTY_RWLockDestroy(MTY_RWLock **rwlock)
 
 	MTY_RWLock *ctx = *rwlock;
 	*rwlock = NULL;
+	MTY_MEMORY_BARRIER();
 
 	mty_rwlock_destroy(&ctx->rwlock);
 	memset(&RWLOCK_STATE[ctx->index], 0, sizeof(struct thread_rwlock));
@@ -172,6 +173,7 @@ void MTY_WaitableDestroy(MTY_Waitable **waitable)
 
 	MTY_Waitable *ctx = *waitable;
 	*waitable = NULL;
+	MTY_MEMORY_BARRIER();
 
 	MTY_CondDestroy(&ctx->cond);
 	MTY_MutexDestroy(&ctx->mutex);
@@ -251,6 +253,7 @@ void MTY_ThreadPoolDestroy(MTY_ThreadPool **pool, MTY_AnonFunc detach)
 
 	MTY_ThreadPool *ctx = *pool;
 	*pool = NULL;
+	MTY_MEMORY_BARRIER();
 
 	for (uint32_t x = 0; x < ctx->num; x++) {
 		MTY_ThreadPoolDetach(ctx, x, detach);

--- a/src/thread.c
+++ b/src/thread.c
@@ -171,16 +171,19 @@ void MTY_WaitableDestroy(MTY_Waitable **waitable)
 		return;
 
 	MTY_Waitable *ctx = *waitable;
+	*waitable = NULL;
 
 	MTY_CondDestroy(&ctx->cond);
 	MTY_MutexDestroy(&ctx->mutex);
 
 	MTY_Free(ctx);
-	*waitable = NULL;
 }
 
 bool MTY_WaitableWait(MTY_Waitable *ctx, int32_t timeout)
 {
+	if (!ctx)
+		return false;
+
 	MTY_MutexLock(ctx->mutex);
 
 	if (!ctx->signal)
@@ -196,6 +199,9 @@ bool MTY_WaitableWait(MTY_Waitable *ctx, int32_t timeout)
 
 void MTY_WaitableSignal(MTY_Waitable *ctx)
 {
+	if (!ctx)
+		return false;
+
 	MTY_MutexLock(ctx->mutex);
 
 	if (!ctx->signal) {

--- a/src/thread.c
+++ b/src/thread.c
@@ -56,7 +56,7 @@ void MTY_RWLockDestroy(MTY_RWLock **rwlock)
 
 	MTY_RWLock *ctx = *rwlock;
 	*rwlock = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	mty_rwlock_destroy(&ctx->rwlock);
 	memset(&RWLOCK_STATE[ctx->index], 0, sizeof(struct thread_rwlock));
@@ -173,7 +173,7 @@ void MTY_WaitableDestroy(MTY_Waitable **waitable)
 
 	MTY_Waitable *ctx = *waitable;
 	*waitable = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	MTY_CondDestroy(&ctx->cond);
 	MTY_MutexDestroy(&ctx->mutex);
@@ -253,7 +253,7 @@ void MTY_ThreadPoolDestroy(MTY_ThreadPool **pool, MTY_AnonFunc detach)
 
 	MTY_ThreadPool *ctx = *pool;
 	*pool = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	for (uint32_t x = 0; x < ctx->num; x++) {
 		MTY_ThreadPoolDetach(ctx, x, detach);

--- a/src/thread.c
+++ b/src/thread.c
@@ -55,17 +55,20 @@ void MTY_RWLockDestroy(MTY_RWLock **rwlock)
 		return;
 
 	MTY_RWLock *ctx = *rwlock;
+	*rwlock = NULL;
 
 	mty_rwlock_destroy(&ctx->rwlock);
 	memset(&RWLOCK_STATE[ctx->index], 0, sizeof(struct thread_rwlock));
 	MTY_Atomic32Set(&RWLOCK_INIT[ctx->index], 0);
 
 	MTY_Free(ctx);
-	*rwlock = NULL;
 }
 
 bool MTY_RWTryLockReader(MTY_RWLock *ctx)
 {
+	if (!ctx)
+		return false;
+
 	struct thread_rwlock *rw = &RWLOCK_STATE[ctx->index];
 
 	bool r = true;
@@ -85,6 +88,9 @@ bool MTY_RWTryLockReader(MTY_RWLock *ctx)
 
 void MTY_RWLockReader(MTY_RWLock *ctx)
 {
+	if (!ctx)
+		return;
+
 	struct thread_rwlock *rw = &RWLOCK_STATE[ctx->index];
 
 	if (rw->taken == 0) {
@@ -99,6 +105,9 @@ void MTY_RWLockReader(MTY_RWLock *ctx)
 
 void MTY_RWLockWriter(MTY_RWLock *ctx)
 {
+	if (!ctx)
+		return;
+
 	bool relock = false;
 	struct thread_rwlock *rw = &RWLOCK_STATE[ctx->index];
 
@@ -120,6 +129,9 @@ void MTY_RWLockWriter(MTY_RWLock *ctx)
 
 void MTY_RWLockUnlock(MTY_RWLock *ctx)
 {
+	if (!ctx)
+		return;
+
 	struct thread_rwlock *rw = &RWLOCK_STATE[ctx->index];
 
 	if (--rw->taken == 0) {

--- a/src/thread.c
+++ b/src/thread.c
@@ -56,7 +56,7 @@ void MTY_RWLockDestroy(MTY_RWLock **rwlock)
 
 	MTY_RWLock *ctx = *rwlock;
 	*rwlock = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	mty_rwlock_destroy(&ctx->rwlock);
 	memset(&RWLOCK_STATE[ctx->index], 0, sizeof(struct thread_rwlock));
@@ -173,7 +173,7 @@ void MTY_WaitableDestroy(MTY_Waitable **waitable)
 
 	MTY_Waitable *ctx = *waitable;
 	*waitable = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	MTY_CondDestroy(&ctx->cond);
 	MTY_MutexDestroy(&ctx->mutex);
@@ -253,7 +253,7 @@ void MTY_ThreadPoolDestroy(MTY_ThreadPool **pool, MTY_AnonFunc detach)
 
 	MTY_ThreadPool *ctx = *pool;
 	*pool = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	for (uint32_t x = 0; x < ctx->num; x++) {
 		MTY_ThreadPoolDetach(ctx, x, detach);

--- a/src/unix/apple/ws.m
+++ b/src/unix/apple/ws.m
@@ -153,10 +153,14 @@ void MTY_WebSocketDestroy(MTY_WebSocket **webSocket)
 		[ctx->task cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure reason:nil];
 
 	if (ctx->session) {
+		id delegate = [ctx->session delegate];
 		[ctx->session finishTasksAndInvalidate];
 
 		if (ctx->conn)
 			MTY_WaitableWait(ctx->conn, INT32_MAX);
+
+		if (delegate)
+			OBJC_CTX_CLEAR(delegate);
 	}
 
 	ctx->session = nil;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -254,11 +254,6 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 		MTY_LogFatal("'pthread_cond_broadcast' failed with error %d", e);
 }
 
-void MTY_MemoryBarrier()
-{
-	MTY_MEMORY_BARRIER();
-}
-
 // Atomic
 
 // XXX Android will complain about the 64-bit atomics on 32-bit platforms,

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -124,7 +124,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 	MTY_Mutex *ctx = *mutex;
 	*mutex = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	int32_t e = pthread_mutex_destroy(&ctx->mutex);
 	if (e != 0)
@@ -190,7 +190,7 @@ void MTY_CondDestroy(MTY_Cond **cond)
 
 	MTY_Cond *ctx = *cond;
 	*cond = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	int32_t e = pthread_cond_destroy(&ctx->cond);
 	if (e != 0)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -234,6 +234,10 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 		MTY_LogFatal("'pthread_cond_broadcast' failed with error %d", e);
 }
 
+void MTY_MemoryBarrier()
+{
+	MTY_MEMORY_BARRIER();
+}
 
 // Atomic
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -123,17 +123,20 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 		return;
 
 	MTY_Mutex *ctx = *mutex;
+	*mutex = NULL;
 
 	int32_t e = pthread_mutex_destroy(&ctx->mutex);
 	if (e != 0)
 		MTY_LogFatal("'pthread_mutex_destroy' failed with error %d", e);
 
 	MTY_Free(ctx);
-	*mutex = NULL;
 }
 
 void MTY_MutexLock(MTY_Mutex *ctx)
 {
+	if (!mutex || !ctx->mutex)
+		return;
+
 	int32_t e = pthread_mutex_lock(&ctx->mutex);
 	if (e != 0)
 		MTY_LogFatal("'pthread_mutex_lock' failed with error %d", e);
@@ -141,6 +144,9 @@ void MTY_MutexLock(MTY_Mutex *ctx)
 
 bool MTY_MutexTryLock(MTY_Mutex *ctx)
 {
+	if (!mutex || !ctx->mutex)
+		return false;
+
 	int32_t e = pthread_mutex_trylock(&ctx->mutex);
 	if (e != 0 && e != EBUSY)
 		MTY_LogFatal("'pthread_mutex_trylock' failed with error %d", e);
@@ -150,6 +156,9 @@ bool MTY_MutexTryLock(MTY_Mutex *ctx)
 
 void MTY_MutexUnlock(MTY_Mutex *ctx)
 {
+	if (!mutex || !ctx->mutex)
+		return;
+
 	int32_t e = pthread_mutex_unlock(&ctx->mutex);
 	if (e != 0)
 		MTY_LogFatal("'pthread_mutex_unlock' failed with error %d", e);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -254,6 +254,7 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 		MTY_LogFatal("'pthread_cond_broadcast' failed with error %d", e);
 }
 
+
 // Atomic
 
 // XXX Android will complain about the 64-bit atomics on 32-bit platforms,

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -188,17 +188,20 @@ void MTY_CondDestroy(MTY_Cond **cond)
 		return;
 
 	MTY_Cond *ctx = *cond;
+	*cond = NULL;
 
 	int32_t e = pthread_cond_destroy(&ctx->cond);
 	if (e != 0)
 		MTY_LogFatal("'pthread_cond_destroy' failed with error %d", e);
 
 	MTY_Free(ctx);
-	*cond = NULL;
 }
 
 bool MTY_CondWait(MTY_Cond *ctx, MTY_Mutex *mutex, int32_t timeout)
 {
+	if (!ctx || !mutex)
+		return false;
+
 	// Use pthread_cond_timedwait
 	if (timeout >= 0) {
 		struct timespec ts = {0};
@@ -231,6 +234,9 @@ bool MTY_CondWait(MTY_Cond *ctx, MTY_Mutex *mutex, int32_t timeout)
 
 void MTY_CondSignal(MTY_Cond *ctx)
 {
+	if (!ctx)
+		return;
+
 	int32_t e = pthread_cond_signal(&ctx->cond);
 	if (e != 0)
 		MTY_LogFatal("'pthread_cond_signal' failed with error %d", e);
@@ -238,6 +244,9 @@ void MTY_CondSignal(MTY_Cond *ctx)
 
 void MTY_CondSignalAll(MTY_Cond *ctx)
 {
+	if (!ctx)
+		return;
+
 	int32_t e = pthread_cond_broadcast(&ctx->cond);
 	if (e != 0)
 		MTY_LogFatal("'pthread_cond_broadcast' failed with error %d", e);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -124,6 +124,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 	MTY_Mutex *ctx = *mutex;
 	*mutex = NULL;
+	MTY_MEMORY_BARRIER();
 
 	int32_t e = pthread_mutex_destroy(&ctx->mutex);
 	if (e != 0)
@@ -189,6 +190,7 @@ void MTY_CondDestroy(MTY_Cond **cond)
 
 	MTY_Cond *ctx = *cond;
 	*cond = NULL;
+	MTY_MEMORY_BARRIER();
 
 	int32_t e = pthread_cond_destroy(&ctx->cond);
 	if (e != 0)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -124,7 +124,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 	MTY_Mutex *ctx = *mutex;
 	*mutex = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	int32_t e = pthread_mutex_destroy(&ctx->mutex);
 	if (e != 0)
@@ -190,7 +190,7 @@ void MTY_CondDestroy(MTY_Cond **cond)
 
 	MTY_Cond *ctx = *cond;
 	*cond = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	int32_t e = pthread_cond_destroy(&ctx->cond);
 	if (e != 0)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -134,7 +134,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 void MTY_MutexLock(MTY_Mutex *ctx)
 {
-	if (!mutex || !ctx->mutex)
+	if (!ctx)
 		return;
 
 	int32_t e = pthread_mutex_lock(&ctx->mutex);
@@ -144,7 +144,7 @@ void MTY_MutexLock(MTY_Mutex *ctx)
 
 bool MTY_MutexTryLock(MTY_Mutex *ctx)
 {
-	if (!mutex || !ctx->mutex)
+	if (!ctx)
 		return false;
 
 	int32_t e = pthread_mutex_trylock(&ctx->mutex);
@@ -156,7 +156,7 @@ bool MTY_MutexTryLock(MTY_Mutex *ctx)
 
 void MTY_MutexUnlock(MTY_Mutex *ctx)
 {
-	if (!mutex || !ctx->mutex)
+	if (!ctx)
 		return;
 
 	int32_t e = pthread_mutex_unlock(&ctx->mutex);

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -169,13 +169,16 @@ void MTY_CondDestroy(MTY_Cond **cond)
 		return;
 
 	MTY_Cond *ctx = *cond;
+	*cond = NULL;
 
 	MTY_Free(ctx);
-	*cond = NULL;
 }
 
 bool MTY_CondWait(MTY_Cond *ctx, MTY_Mutex *mutex, int32_t timeout)
 {
+	if (!ctx || !mutex)
+		return false;
+
 	bool r = true;
 	timeout = timeout < 0 ? INFINITE : timeout;
 
@@ -197,11 +200,17 @@ bool MTY_CondWait(MTY_Cond *ctx, MTY_Mutex *mutex, int32_t timeout)
 
 void MTY_CondSignal(MTY_Cond *ctx)
 {
+	if (!ctx)
+		return;
+
 	WakeConditionVariable(&ctx->cond);
 }
 
 void MTY_CondSignalAll(MTY_Cond *ctx)
 {
+	if (!ctx)
+		return;
+
 	WakeAllConditionVariable(&ctx->cond);
 }
 

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -216,11 +216,6 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 	WakeAllConditionVariable(&ctx->cond);
 }
 
-void MTY_MemoryBarrier()
-{
-	MTY_MEMORY_BARRIER();
-}
-
 // Atomic
 
 void MTY_Atomic32Set(MTY_Atomic32 *atomic, int32_t value)

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -116,25 +116,34 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 		return;
 
 	MTY_Mutex *ctx = *mutex;
+	*mutex = NULL;
 
 	DeleteCriticalSection(&ctx->mutex);
 
 	MTY_Free(ctx);
-	*mutex = NULL;
 }
 
 void MTY_MutexLock(MTY_Mutex *ctx)
 {
+	if (!ctx)
+		return;
+
 	EnterCriticalSection(&ctx->mutex);
 }
 
 bool MTY_MutexTryLock(MTY_Mutex *ctx)
 {
+	if (!ctx)
+		return false;;
+
 	return TryEnterCriticalSection(&ctx->mutex);
 }
 
 void MTY_MutexUnlock(MTY_Mutex *ctx)
 {
+	if (!ctx)
+		return;
+
 	LeaveCriticalSection(&ctx->mutex);
 }
 

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -117,7 +117,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 	MTY_Mutex *ctx = *mutex;
 	*mutex = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	DeleteCriticalSection(&ctx->mutex);
 
@@ -171,7 +171,7 @@ void MTY_CondDestroy(MTY_Cond **cond)
 
 	MTY_Cond *ctx = *cond;
 	*cond = NULL;
-	MTY_MemoryBarrier();
+	MTY_MEMORY_BARRIER();
 
 	MTY_Free(ctx);
 }

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -135,7 +135,7 @@ void MTY_MutexLock(MTY_Mutex *ctx)
 bool MTY_MutexTryLock(MTY_Mutex *ctx)
 {
 	if (!ctx)
-		return false;;
+		return false;
 
 	return TryEnterCriticalSection(&ctx->mutex);
 }

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -117,7 +117,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 	MTY_Mutex *ctx = *mutex;
 	*mutex = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	DeleteCriticalSection(&ctx->mutex);
 
@@ -171,7 +171,7 @@ void MTY_CondDestroy(MTY_Cond **cond)
 
 	MTY_Cond *ctx = *cond;
 	*cond = NULL;
-	MTY_MEMORY_BARRIER();
+	MTY_MemoryBarrier();
 
 	MTY_Free(ctx);
 }

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -216,6 +216,7 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 	WakeAllConditionVariable(&ctx->cond);
 }
 
+
 // Atomic
 
 void MTY_Atomic32Set(MTY_Atomic32 *atomic, int32_t value)

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -117,6 +117,7 @@ void MTY_MutexDestroy(MTY_Mutex **mutex)
 
 	MTY_Mutex *ctx = *mutex;
 	*mutex = NULL;
+	MTY_MEMORY_BARRIER();
 
 	DeleteCriticalSection(&ctx->mutex);
 
@@ -170,6 +171,7 @@ void MTY_CondDestroy(MTY_Cond **cond)
 
 	MTY_Cond *ctx = *cond;
 	*cond = NULL;
+	MTY_MEMORY_BARRIER();
 
 	MTY_Free(ctx);
 }

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -196,6 +196,10 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 	WakeAllConditionVariable(&ctx->cond);
 }
 
+void MTY_MemoryBarrier()
+{
+	MTY_MEMORY_BARRIER();
+}
 
 // Atomic
 


### PR DESCRIPTION
When destroying threading-related contexts, the NULL assignment is moved to be first.
When calling other threading-related functions, the context is NULL-checked first.

This should help prevent some rare and specific race conditions around the calling of threading functions during or after the destruction of their contexts.