### PR TITLE
Better webview focus

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -629,7 +629,6 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 		}
 		case WM_SETFOCUS:
 		case WM_KILLFOCUS:
-			evt.type = MTY_EVENT_FOCUS;
 			evt.focus = msg == WM_SETFOCUS;
 
 			// This block effectively coalesces focus events between the normal and webview windows
@@ -640,6 +639,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			if ((webview_visible && !webview_focus_evt) || focus_unchanged)
 				break;
 
+			evt.type = MTY_EVENT_FOCUS;
 			app->state++;
 			break;
 		case WM_QUERYENDSESSION:

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -630,6 +630,8 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 		case WM_SETFOCUS:
 		case WM_KILLFOCUS:
 			evt.focus = msg == WM_SETFOCUS;
+			if (mty_webview_is_visible(ctx->cmn.webview))
+				evt.focus = mty_webview_is_focussed(ctx->cmn.webview);
 
 			// This block effectively coalesces focus events between the normal and webview windows
 			bool webview_visible = mty_webview_is_visible(ctx->cmn.webview);

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -634,11 +634,9 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 				evt.focus = mty_webview_is_focussed(ctx->cmn.webview);
 
 			// This block effectively coalesces focus events between the normal and webview windows
-			bool webview_visible = mty_webview_is_visible(ctx->cmn.webview);
-			bool webview_focus_evt = evt.focus == mty_webview_is_focussed(ctx->cmn.webview);
 			bool focus_unchanged = ctx->was_focussed == evt.focus;
 			ctx->was_focussed = evt.focus;
-			if ((webview_visible && !webview_focus_evt) || focus_unchanged)
+			if (focus_unchanged)
 				break;
 
 			evt.type = MTY_EVENT_FOCUS;


### PR DESCRIPTION
The previous solution I had to integrate webview focus events into Matoya just about worked for fixing the issue of switching to/from using a webview, and having focus events in general.

Unfortunately it didn't do a good job of ensuring the triggered event was _correct_, and didn't deduplicate events because of a flaw in my deduplication.

This is a MUCH better solution, forcing all focus events to use the focus state of the webview when the webview is visible, and _properly_ skipping events when the event would be the same as the previous.

This has been tested against the previous problem case, and the new one, and works as intended so far.
This change only affects applications with an active WebView.