### PR TITLE
[macOS - Improvement] Add compatibility with Karabiner Elements

### DIFF
--- a/src/unix/apple/macosx/hid.c
+++ b/src/unix/apple/macosx/hid.c
@@ -6,6 +6,7 @@
 
 #include <IOKit/hid/IOHIDManager.h>
 #include <IOKit/hid/IOHIDKeys.h>
+#include <IOKit/IOKitLib.h>
 
 #define HID_DEV_GET_USAGE(dev) \
 	hid_device_get_prop_int(dev, CFSTR(kIOHIDPrimaryUsageKey))

--- a/src/unix/apple/macosx/hid.c
+++ b/src/unix/apple/macosx/hid.c
@@ -172,7 +172,7 @@ struct hid *mty_hid_create(HID_CONNECT connect, HID_DISCONNECT disconnect, HID_R
 		CFMutableDictionaryRef d4 = IOServiceNameMatching("org_pqrs_Karabiner_DriverKit_VirtualHIDKeyboard");
 		CFMutableDictionaryRef dict_list2[] = {d0, d1, d2, d4};
 
-		CFArrayRef matches2 = CFArrayCreate(kCFAllocatorDefault, (const void **) dict_list2, 4, NULL);
+		CFArrayRef matches2 = CFArrayCreate(kCFAllocatorDefault, (const void **) dict_list2, sizeof(dict_list2) / sizeof(dict_list2[0]), NULL);
 		IOHIDManagerSetDeviceMatchingMultiple(ctx->mgr, matches2);
 
 		CFRelease(matches2);

--- a/src/unix/apple/macosx/hid.c
+++ b/src/unix/apple/macosx/hid.c
@@ -164,15 +164,15 @@ struct hid *mty_hid_create(HID_CONNECT connect, HID_DISCONNECT disconnect, HID_R
 	CFArrayRef matches = CFArrayCreate(kCFAllocatorDefault, (const void **) dict_list, key ? 4 : 3, NULL);
 	IOHIDManagerSetDeviceMatchingMultiple(ctx->mgr, matches);
 
+	IOHIDManagerScheduleWithRunLoop(ctx->mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+
+	IOReturn e = IOHIDManagerOpen(ctx->mgr, kIOHIDOptionsTypeNone);
 	CFRelease(matches);
 	CFRelease(d3);
 	CFRelease(d2);
 	CFRelease(d1);
 	CFRelease(d0);
 
-	IOHIDManagerScheduleWithRunLoop(ctx->mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-
-	IOReturn e = IOHIDManagerOpen(ctx->mgr, kIOHIDOptionsTypeNone);
 	if (e != kIOReturnSuccess) {
 		r = false;
 		MTY_Log("'IOHIDManagerOpen' failed with error 0x%X", e);

--- a/src/unix/apple/macosx/hid.c
+++ b/src/unix/apple/macosx/hid.c
@@ -167,6 +167,19 @@ struct hid *mty_hid_create(HID_CONNECT connect, HID_DISCONNECT disconnect, HID_R
 	IOHIDManagerScheduleWithRunLoop(ctx->mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
 
 	IOReturn e = IOHIDManagerOpen(ctx->mgr, kIOHIDOptionsTypeNone);
+	if (e == kIOReturnExclusiveAccess && key) {
+		CFMutableDictionaryRef d4 = IOServiceNameMatching("org_pqrs_Karabiner_DriverKit_VirtualHIDKeyboard");
+		CFMutableDictionaryRef dict_list2[] = {d0, d1, d2, d4};
+
+		CFArrayRef matches2 = CFArrayCreate(kCFAllocatorDefault, (const void **) dict_list2, 4, NULL);
+		IOHIDManagerSetDeviceMatchingMultiple(ctx->mgr, matches);
+
+		CFRelease(matches2);
+		CFRelease(d4);
+
+		e = IOHIDManagerOpen(ctx->mgr, kIOHIDOptionsTypeNone);
+	}
+
 	CFRelease(matches);
 	CFRelease(d3);
 	CFRelease(d2);

--- a/src/unix/apple/macosx/hid.c
+++ b/src/unix/apple/macosx/hid.c
@@ -173,12 +173,14 @@ struct hid *mty_hid_create(HID_CONNECT connect, HID_DISCONNECT disconnect, HID_R
 		CFMutableDictionaryRef dict_list2[] = {d0, d1, d2, d4};
 
 		CFArrayRef matches2 = CFArrayCreate(kCFAllocatorDefault, (const void **) dict_list2, 4, NULL);
-		IOHIDManagerSetDeviceMatchingMultiple(ctx->mgr, matches);
+		IOHIDManagerSetDeviceMatchingMultiple(ctx->mgr, matches2);
 
 		CFRelease(matches2);
 		CFRelease(d4);
 
 		e = IOHIDManagerOpen(ctx->mgr, kIOHIDOptionsTypeNone);
+		if (e == kIOReturnSuccess)
+			MTY_Log("Using Karabiner compatibility for IOHID access.");
 	}
 
 	CFRelease(matches);


### PR DESCRIPTION
Karabiner takes exclusive access to the keyboard device(s), preventing libmatoya from opening it for HID purposes.
Libmatoya takes non-exclusive access, though changing that would have no impact on the issue.

According to [this github comment](https://github.com/pqrs-org/Karabiner-Elements/issues/2560#issuecomment-2008694402), we can try opening the Karabiner HID keyboard instead of "all keyboards" in this case.

In my testing, this works as expected, allowing Karabiner to continue to do its work without getting in the way of libmatoya-based apps that want HID keyboard access. 