### PR TITLE
[Windows - Improvement] Better checking of WebView2 availability

### DIFF
--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -579,16 +579,17 @@ static bool webview_dll_path(wchar_t *pathw, bool as_user)
 static HMODULE webview_load_dll(void)
 {
 	wchar_t path[MTY_PATH_MAX] = {0};
+	HMODULE ret = NULL;
 
 	// Try system WebView
 	if (webview_dll_path(path, false))
-		return LoadLibrary(path);
+		ret = LoadLibrary(path);
 
 	// Try user WebView
-	if (webview_dll_path(path, true))
-		return LoadLibrary(path);
+	if (!ret && webview_dll_path(path, true))
+		ret = LoadLibrary(path);
 
-	return NULL;
+	return ret;
 }
 
 struct webview *mty_webview_create(MTY_App *app, MTY_Window window, const char *dir,

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -564,7 +564,8 @@ struct webview *mty_webview_create(MTY_App *app, MTY_Window window, const char *
 	ctx->handler4.opaque = ctx;
 	ctx->opts.lpVtbl = &VTBL5;
 
-	const WCHAR *dirw = dir ? MTY_MultiToWideDL(dir) : L"webview-data";
+	WCHAR dirw[MTY_PATH_MAX] = {0};
+	MTY_MultiToWide(dir ? dir : "webview-data", dirw, MTY_PATH_MAX);
 
 	HRESULT e = E_FAIL;
 	ctx->lib = webview_load_dll();

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -16,9 +16,7 @@
 #include "unix/web/keymap.h"
 
 // https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
-// Using ClientState to get `EBWebView` key, instead of using Clients and fetching both `location` and `pv`
-#define WEBVIEW_MACHINE_REG_PATH L"Software\\Microsoft\\EdgeUpdate\\%s\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
-#define WEBVIEW_USER_REG_PATH L"Software\\Microsoft\\EdgeUpdate\\%s\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+#define WEBVIEW_REG_PATH L"Software\\Microsoft\\EdgeUpdate\\%s\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
 
 #if defined(_WIN64)
 	#define WEBVIEW_DLL_PATH L"EBWebView\\x64\\EmbeddedBrowserWebView.dll"
@@ -494,11 +492,10 @@ static bool webview_dll_path_clientstate(wchar_t *pathw, bool as_user)
 {
 	bool ok = false;
 
-	const wchar_t *reg_path_fmt = as_user ? WEBVIEW_USER_REG_PATH : WEBVIEW_MACHINE_REG_PATH;
 	HKEY hkey = as_user ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
 
 	wchar_t reg_path[MAX_PATH] = {0};
-	_snwprintf_s(reg_path, MAX_PATH, _TRUNCATE, reg_path_fmt, L"ClientState");
+	_snwprintf_s(reg_path, MAX_PATH, _TRUNCATE, WEBVIEW_REG_PATH, L"ClientState");
 
 	HKEY key = NULL;
 	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
@@ -528,11 +525,10 @@ static bool webview_dll_path_client(wchar_t *pathw, bool as_user)
 {
 	bool ok = false;
 
-	const wchar_t *reg_path_fmt = as_user ? WEBVIEW_USER_REG_PATH : WEBVIEW_MACHINE_REG_PATH;
 	HKEY hkey = as_user ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
 
 	wchar_t reg_path[MAX_PATH] = {0};
-	_snwprintf_s(reg_path, MAX_PATH, _TRUNCATE, reg_path_fmt, L"Clients");
+	_snwprintf_s(reg_path, MAX_PATH, _TRUNCATE, WEBVIEW_REG_PATH, L"Clients");
 
 	HKEY key = NULL;
 	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -491,14 +491,17 @@ static ICoreWebView2EnvironmentOptionsVtbl VTBL5 = {
 static bool webview_dll_path_clientstate(wchar_t *pathw, bool as_user)
 {
 	bool ok = false;
+	DWORD flags = KEY_READ;
 
 	HKEY hkey = as_user ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
+	if (!as_user)
+		flags |= KEY_WOW64_32KEY;
 
 	wchar_t reg_path[MAX_PATH] = {0};
 	_snwprintf_s(reg_path, MAX_PATH, _TRUNCATE, WEBVIEW_REG_PATH, L"ClientState");
 
 	HKEY key = NULL;
-	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
+	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, flags, &key);
 	if (r != ERROR_SUCCESS)
 		goto except;
 
@@ -524,14 +527,17 @@ static bool webview_dll_path_clientstate(wchar_t *pathw, bool as_user)
 static bool webview_dll_path_client(wchar_t *pathw, bool as_user)
 {
 	bool ok = false;
+	DWORD flags = KEY_READ;
 
 	HKEY hkey = as_user ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
+	if (!as_user)
+		flags |= KEY_WOW64_32KEY;
 
 	wchar_t reg_path[MAX_PATH] = {0};
 	_snwprintf_s(reg_path, MAX_PATH, _TRUNCATE, WEBVIEW_REG_PATH, L"Clients");
 
 	HKEY key = NULL;
-	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
+	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, flags, &key);
 	if (r != ERROR_SUCCESS)
 		goto except;
 

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -763,5 +763,5 @@ bool mty_webview_is_available(void)
 
 	// Loading the lib would be ideal to be sure, but repeated loads eventually cause issues from Windows not un-reserving memory.
 	// https://forums.codeguru.com/showthread.php?60548-Is-there-a-limit-on-how-many-times-one-can-load-(and-free)-the-same-DLL-in-a-process&p=156821#post156821
-	return false;
+	return have_path;
 }

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -712,6 +712,7 @@ bool mty_webview_is_available(void)
 	if (!have_path)
 		return false;
 
-	// Loading the lib would be ideal to be sure, but repeated loads eventually cause issues
+	// Loading the lib would be ideal to be sure, but repeated loads eventually cause issues from Windows not un-reserving memory.
+	// https://forums.codeguru.com/showthread.php?60548-Is-there-a-limit-on-how-many-times-one-can-load-(and-free)-the-same-DLL-in-a-process&p=156821#post156821
 	return PathFileExists(path);
 }

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -8,6 +8,7 @@
 
 #include <windows.h>
 #include <ole2.h>
+#include <shlwapi.h>
 
 #define COBJMACROS
 #include "webview2.h"
@@ -701,19 +702,15 @@ bool mty_webview_is_steam(void)
 
 bool mty_webview_is_available(void)
 {
-	WCHAR pathw[MTY_PATH_MAX] = {0};
+	WCHAR path[MTY_PATH_MAX] = {0};
 
-	bool have_path = webview_dll_path(pathw, false);
+	bool have_path = webview_dll_path(path, false);
 	if (!have_path)
-		have_path = webview_dll_path(pathw, true);
+		have_path = webview_dll_path(path, true);
 
 	if (!have_path)
-		return false;
-
-	char path[MTY_PATH_MAX] = {0};
-	if (!MTY_WideToMulti(pathw, path, MTY_PATH_MAX))
 		return false;
 
 	// Loading the lib would be ideal to be sure, but repeated loads eventually cause issues
-	return MTY_FileExists(path);
+	return PathFileExists(path);
 }

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -16,8 +16,9 @@
 #include "unix/web/keymap.h"
 
 // https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
+// Using ClientState to get `EBWebView` key, instead of using Clients and fetching both `location` and `pv`
 #define WEBVIEW_MACHINE_REG_PATH L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
-#define WEBVIEW_USER_REG_PATH L"Software\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+#define WEBVIEW_USER_REG_PATH L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
 
 #if defined(_WIN64)
 	#define WEBVIEW_DLL_PATH L"\\EBWebView\\x64\\EmbeddedBrowserWebView.dll"

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -477,6 +477,51 @@ static ICoreWebView2EnvironmentOptionsVtbl VTBL5 = {
 
 // Public
 
+static bool webview_dll_path(WCHAR *path, bool as_user)
+{
+	bool ok = false;
+
+	HKEY key = NULL;
+	WCHAR dll[MTY_PATH_MAX] = {0};
+	HMODULE lib = NULL;
+
+	// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
+	const char *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+	const char *user_path = L"Software\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+	const char *path = as_user ? user_path : machine_path;
+
+	LSTATUS r = RegOpenKeyEx(HKEY_LOCAL_MACHINE, path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
+	if (r != ERROR_SUCCESS)
+		goto except;
+
+	DWORD size = MTY_PATH_MAX * sizeof(WCHAR);
+	r = RegQueryValueEx(key, L"EBWebView", 0, NULL, (BYTE *) dll, &size);
+	if (r != ERROR_SUCCESS)
+		goto except;
+
+	#if defined(_WIN64)
+		const WCHAR *path = L"\\EBWebView\\x64\\EmbeddedBrowserWebView.dll";
+
+	#else
+		const WCHAR *path = L"\\EBWebView\\x86\\EmbeddedBrowserWebView.dll";
+	#endif
+
+	if (wcscat_s(dll, MTY_PATH_MAX, path) != 0)
+		goto except;
+
+	if (path)
+		_snwprintf_s(path, MTY_PATH_MAX, _TRUNCATE, L"%s", dll);
+
+	ok = true;
+
+	except:
+
+	if (key)
+		RegCloseKey(key);
+
+	return ok;
+}
+
 static HMODULE webview_load_dll(void)
 {
 	HKEY key = NULL;

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -511,10 +511,9 @@ static bool webview_dll_path_clientstate(wchar_t *pathw, bool as_user)
 	if (r != ERROR_SUCCESS)
 		goto except;
 
-	if (pathw)
-		_snwprintf_s(pathw, MTY_PATH_MAX, _TRUNCATE, L"%s\\%s", dll, WEBVIEW_DLL_PATH);
+	_snwprintf_s(pathw, MTY_PATH_MAX, _TRUNCATE, L"%s\\%s", dll, WEBVIEW_DLL_PATH);
 
-	ok = true;
+	ok = PathFileExists(pathw);
 
 	except:
 
@@ -553,10 +552,9 @@ static bool webview_dll_path_client(wchar_t *pathw, bool as_user)
 	if (r != ERROR_SUCCESS)
 		goto except;
 
-	if (pathw)
-		_snwprintf_s(pathw, MTY_PATH_MAX, _TRUNCATE, L"%s\\%s\\%s", dll, version, WEBVIEW_DLL_PATH);
+	_snwprintf_s(pathw, MTY_PATH_MAX, _TRUNCATE, L"%s\\%s\\%s", dll, version, WEBVIEW_DLL_PATH);
 
-	ok = true;
+	ok = PathFileExists(pathw);
 
 	except:
 
@@ -763,10 +761,7 @@ bool mty_webview_is_available(void)
 	if (!have_path)
 		have_path = webview_dll_path(path, true);
 
-	if (!have_path)
-		return false;
-
 	// Loading the lib would be ideal to be sure, but repeated loads eventually cause issues from Windows not un-reserving memory.
 	// https://forums.codeguru.com/showthread.php?60548-Is-there-a-limit-on-how-many-times-one-can-load-(and-free)-the-same-DLL-in-a-process&p=156821#post156821
-	return PathFileExists(path);
+	return false;
 }

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -701,11 +701,19 @@ bool mty_webview_is_steam(void)
 
 bool mty_webview_is_available(void)
 {
-	HMODULE webview = webview_load_dll();
-	if (webview) {
-		FreeLibrary(webview);
-		return true;
-	}
+	WCHAR pathw[MTY_PATH_MAX] = {0};
 
-	return false;
+	bool have_path = webview_dll_path(pathw, false);
+	if (!have_path)
+		have_path = webview_dll_path(pathw, true);
+
+	if (!have_path)
+		return false;
+
+	char path[MTY_PATH_MAX] = {0};
+	if (!MTY_WideToMulti(pathw, path, MTY_PATH_MAX))
+		return false;
+
+	// Loading the lib would be ideal to be sure, but repeated loads eventually cause issues
+	return MTY_FileExists(path);
 }

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -483,7 +483,6 @@ static bool webview_dll_path(WCHAR *pathw, bool as_user)
 
 	HKEY key = NULL;
 	WCHAR dll[MTY_PATH_MAX] = {0};
-	HMODULE lib = NULL;
 
 	// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
 	const wchar_t *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -488,9 +488,9 @@ static bool webview_dll_path(WCHAR *path, bool as_user)
 	// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
 	const char *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
 	const char *user_path = L"Software\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
-	const char *path = as_user ? user_path : machine_path;
+	const char *reg_path = as_user ? user_path : machine_path;
 
-	LSTATUS r = RegOpenKeyEx(HKEY_LOCAL_MACHINE, path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
+	LSTATUS r = RegOpenKeyEx(HKEY_LOCAL_MACHINE, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
 	if (r != ERROR_SUCCESS)
 		goto except;
 

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -478,12 +478,12 @@ static ICoreWebView2EnvironmentOptionsVtbl VTBL5 = {
 
 // Public
 
-static bool webview_dll_path(WCHAR *pathw, bool as_user)
+static bool webview_dll_path(wchar_t *pathw, bool as_user)
 {
 	bool ok = false;
 
 	HKEY key = NULL;
-	WCHAR dll[MTY_PATH_MAX] = {0};
+	wchar_t dll[MTY_PATH_MAX] = {0};
 
 	// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
 	const wchar_t *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
@@ -494,16 +494,16 @@ static bool webview_dll_path(WCHAR *pathw, bool as_user)
 	if (r != ERROR_SUCCESS)
 		goto except;
 
-	DWORD size = MTY_PATH_MAX * sizeof(WCHAR);
+	DWORD size = MTY_PATH_MAX * sizeof(wchar_t);
 	r = RegQueryValueEx(key, L"EBWebView", 0, NULL, (BYTE *) dll, &size);
 	if (r != ERROR_SUCCESS)
 		goto except;
 
 	#if defined(_WIN64)
-		const WCHAR *path = L"\\EBWebView\\x64\\EmbeddedBrowserWebView.dll";
+		const wchar_t *path = L"\\EBWebView\\x64\\EmbeddedBrowserWebView.dll";
 
 	#else
-		const WCHAR *path = L"\\EBWebView\\x86\\EmbeddedBrowserWebView.dll";
+		const wchar_t *path = L"\\EBWebView\\x86\\EmbeddedBrowserWebView.dll";
 	#endif
 
 	if (wcscat_s(dll, MTY_PATH_MAX, path) != 0)
@@ -524,7 +524,7 @@ static bool webview_dll_path(WCHAR *pathw, bool as_user)
 
 static HMODULE webview_load_dll(void)
 {
-	WCHAR path[MTY_PATH_MAX] = {0};
+	wchar_t path[MTY_PATH_MAX] = {0};
 
 	// Try system WebView
 	if (webview_dll_path(path, false))
@@ -702,7 +702,7 @@ bool mty_webview_is_steam(void)
 
 bool mty_webview_is_available(void)
 {
-	WCHAR path[MTY_PATH_MAX] = {0};
+	wchar_t path[MTY_PATH_MAX] = {0};
 
 	bool have_path = webview_dll_path(path, false);
 	if (!have_path)

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -477,7 +477,7 @@ static ICoreWebView2EnvironmentOptionsVtbl VTBL5 = {
 
 // Public
 
-static bool webview_dll_path(WCHAR *path, bool as_user)
+static bool webview_dll_path(WCHAR *pathw, bool as_user)
 {
 	bool ok = false;
 
@@ -486,9 +486,9 @@ static bool webview_dll_path(WCHAR *path, bool as_user)
 	HMODULE lib = NULL;
 
 	// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-webview2-runtime-is-already-installed
-	const char *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
-	const char *user_path = L"Software\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
-	const char *reg_path = as_user ? user_path : machine_path;
+	const wchar_t *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+	const wchar_t *user_path = L"Software\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+	const wchar_t *reg_path = as_user ? user_path : machine_path;
 
 	LSTATUS r = RegOpenKeyEx(HKEY_LOCAL_MACHINE, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
 	if (r != ERROR_SUCCESS)
@@ -509,8 +509,8 @@ static bool webview_dll_path(WCHAR *path, bool as_user)
 	if (wcscat_s(dll, MTY_PATH_MAX, path) != 0)
 		goto except;
 
-	if (path)
-		_snwprintf_s(path, MTY_PATH_MAX, _TRUNCATE, L"%s", dll);
+	if (pathw)
+		_snwprintf_s(pathw, MTY_PATH_MAX, _TRUNCATE, L"%s", dll);
 
 	ok = true;
 

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -489,8 +489,9 @@ static bool webview_dll_path(wchar_t *pathw, bool as_user)
 	const wchar_t *machine_path = L"Software\\Microsoft\\EdgeUpdate\\ClientState\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
 	const wchar_t *user_path = L"Software\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
 	const wchar_t *reg_path = as_user ? user_path : machine_path;
+	HKEY hkey = as_user ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
 
-	LSTATUS r = RegOpenKeyEx(HKEY_LOCAL_MACHINE, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
+	LSTATUS r = RegOpenKeyEx(hkey, reg_path, 0, KEY_WOW64_32KEY | KEY_READ, &key);
 	if (r != ERROR_SUCCESS)
 		goto except;
 


### PR DESCRIPTION
Splits out determining the DLL path into a dedicated function, selecting either the Machine or User version of the WebView depending on a boolean param.

Reworks the DLL load to try the Machine version first using the new function, then the User version if not available.

Rewrites the availability check to just determine if the WebView DLL exists at either path. 

Repeated DLL loads eventually cause DLL init failures due to Windows not fully cleaning up libraries after FreeLibrary, and just forever incrementing the memory addresses new DLLs are loaded into. 
This has been an issue in Windows since 1999!

A small extra change added as I was in the area; `mty_webview_create` no longer gives a thread-local string to `CreateWebViewEnvironmentWithOptionsInternal`