### PR TITLE
Fix for audio playback on Windows clients going silent when audio device is invalidated

### DIFF
--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -406,8 +406,10 @@ uint32_t MTY_AudioGetQueued(MTY_Audio *ctx)
 
 void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 {
-	if (!audio_handle_device_change(ctx))
+	if (!audio_handle_device_change(ctx)) {
+		MTY_Log("\"audio_handle_device_change\" returned false. Switching default device is still in progress?");
 		return;
+	}
 
 	uint32_t queued = audio_get_queued_frames(ctx);
 
@@ -422,6 +424,8 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 		if (e == S_OK) {
 			memcpy(buffer, frames, count * ctx->channels * AUDIO_SAMPLE_SIZE);
 			IAudioRenderClient_ReleaseBuffer(ctx->render, count, 0);
+		} else {
+			MTY_Log("\"IAudioRenderClient_GetBuffer\" failed with HRESULT 0x%X...frames %u queued %u buffer_size %u", e, count, queued, ctx->buffer_size);
 		}
 
 		// Begin playing again when the minimum buffer has been reached

--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -413,9 +413,13 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 
 	uint32_t queued = audio_get_queued_frames(ctx);
 
+	MTY_Log("count %u | (buffer_size %u - queued %u) = %u | max_buffer %u", count, ctx->buffer_size, queued, ctx->buffer_size - queued, ctx->max_buffer);
+
 	// Stop playing and flush if we've exceeded the maximum buffer or underrun
-	if (ctx->playing && (queued > ctx->max_buffer || queued == 0))
+	if (ctx->playing && (queued > ctx->max_buffer || queued == 0)) {
+		MTY_Log("Exceeded maximum buffer or underrun. queued %u > max_buffer %u || queued %u == 0", queued, ctx->max_buffer, queued);
 		MTY_AudioReset(ctx);
+	}
 
 	if (ctx->buffer_size - queued >= count) {
 		BYTE *buffer = NULL;
@@ -423,7 +427,9 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 
 		if (e == S_OK) {
 			memcpy(buffer, frames, count * ctx->channels * AUDIO_SAMPLE_SIZE);
-			IAudioRenderClient_ReleaseBuffer(ctx->render, count, 0);
+			e = IAudioRenderClient_ReleaseBuffer(ctx->render, count, 0);
+			MTY_Log("\"IAudioRenderClient_ReleaseBuffer\" result is 0x%X", e);
+
 		} else {
 			MTY_Log("\"IAudioRenderClient_GetBuffer\" failed with HRESULT 0x%X...frames %u queued %u buffer_size %u", e, count, queued, ctx->buffer_size);
 		}

--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -22,6 +22,9 @@ DEFINE_GUID(IID_IMMNotificationClient, 0x7991EEC9, 0x7E89, 0x4D85, 0x83, 0x90, 0
 #define AUDIO_SAMPLE_SIZE sizeof(int16_t)
 #define AUDIO_BUFFER_SIZE ((1 * 1000 * 1000 * 1000) / 100) // 1 second
 
+#define AUDIO_REINIT_MAX_TRIES   5
+#define AUDIO_REINIT_DELAY_MS  100
+
 struct MTY_Audio {
 	bool playing;
 	bool notification_init;
@@ -399,13 +402,13 @@ static HRESULT audio_reinit_device(MTY_Audio *ctx)
 
 	// When the default device is in the process of changing, this may fail so we try multiple times
 	HRESULT e = AUDCLNT_E_NOT_INITIALIZED;
-	for (uint8_t x = 0; x < 5; x++) {
+	for (uint8_t x = 0; x < AUDIO_REINIT_MAX_TRIES; x++) {
 		e = audio_device_create(ctx);
 
 		if (e == S_OK && ctx->client)
 			break;
 
-		MTY_Sleep(100);
+		MTY_Sleep(AUDIO_REINIT_DELAY_MS);
 	}
 
 	return e;

--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -336,25 +336,17 @@ void MTY_AudioDestroy(MTY_Audio **audio)
 
 static HRESULT audio_get_queued_frames(MTY_Audio *ctx, uint32_t *out)
 {
-	HRESULT e = S_OK;
-	uint32_t frames = ctx->buffer_size; // indicates that the buffer is full, which also serves
-	                                    // as a useful return value in the case of an error.
+	*out = ctx->buffer_size; // indicates that the buffer is full, which also serves
+	                         // as a useful return value in the case of an error.
 
-	if (!ctx->client) {
-		e = AUDCLNT_E_NOT_INITIALIZED;
-		goto except;
-	}
+	if (!ctx->client)
+		return AUDCLNT_E_NOT_INITIALIZED;
 
 	UINT32 padding = 0;
-	e = IAudioClient_GetCurrentPadding(ctx->client, &padding);
-	if (e != S_OK)
-		goto except;
+	HRESULT e = IAudioClient_GetCurrentPadding(ctx->client, &padding);
+	if (e == S_OK)
+		*out = padding;
 
-	frames = padding;
-
-	except:
-
-	*out = frames;
 	return e;
 }
 
@@ -449,7 +441,7 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 			return;
 		}
 
-		e = audio_get_queued_frames(ctx, &queued);
+		audio_get_queued_frames(ctx, &queued);
 	}
 
 	// Stop playing and flush if we've exceeded the maximum buffer or underrun


### PR DESCRIPTION
Turns out that some AI voice gen app that Richard was using was inadvertently causing the Parsec client audio playback device to be invalidated. I was unable to repro this myself using the same software however it is 100% reproducible on Richard's setup.

My solution: simply reinitialize the IAudioClient device, just like we do when detecting the default device has changed (in the case where playback is happening on the default device). The solution is generic and solves the problem in the future for any other scenario where the device is invalidated for w/e reason.