### PR TITLE
Do not access member of NULL ptr

### DIFF
--- a/src/unix/linux/x11/app.c
+++ b/src/unix/linux/x11/app.c
@@ -94,7 +94,7 @@ static MTY_Window app_find_window(MTY_App *ctx, Window xwindow)
 	for (MTY_Window x = 0; x < MTY_WINDOW_MAX; x++) {
 		struct window *win = app_get_window(ctx, x);
 
-		if (win->window == xwindow)
+		if (win && win->window == xwindow)
 			return x;
 	}
 


### PR DESCRIPTION
If you open three windows and then close the second one, the third will cause an access violation upon the next window event it receives while trying to find the Matoya window associated with the xwindow.