### PR TITLE
Wide-char array declaration has unnecessary extra wide-char size factor

### DIFF
--- a/src/windows/dialog.c
+++ b/src/windows/dialog.c
@@ -36,7 +36,7 @@ void MTY_ShowMessageBox(const char *title, const char *fmt, ...)
 
 const char *MTY_OpenFile(const char *title, MTY_App *app, MTY_Window window)
 {
-	WCHAR file[MTY_PATH_MAX * sizeof(WCHAR)] = L"";
+	WCHAR file[MTY_PATH_MAX] = L"";
 
 	OPENFILENAME ofn = {0};
 	ofn.lStructSize = sizeof(OPENFILENAME);


### PR DESCRIPTION
I searched the rest of the codebase. This appears to be the only place we've made this mistake.

Note that because the variable `file` is declared already as a `WCHAR`, the extra `sizeof(WCHAR)` factor is not needed and is a waste of space.