### PR TITLE
for cross-platform code to use a memory barrier, there must be a function (not just a macro)

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2827,6 +2827,10 @@ MTY_ThreadPoolDetach(MTY_ThreadPool *ctx, uint32_t index, MTY_AnonFunc detach);
 MTY_EXPORT MTY_Async
 MTY_ThreadPoolPoll(MTY_ThreadPool *ctx, uint32_t index, void **opaque);
 
+/// @brief Force code above barrier to complete, before code below barrier begins.
+MTY_EXPORT void
+MTY_MemoryBarrier();
+
 /// @brief Set a 32-bit integer atomically.
 /// @details All atomic operations in libmatoya create a full memory barrier.
 /// @param atomic An MTY_Atomic32.

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -234,6 +234,10 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 		MTY_LogFatal("'pthread_cond_broadcast' failed with error %d", e);
 }
 
+void MTY_MemoryBarrier()
+{
+	MTY_MEMORY_BARRIER();
+}
 
 // Atomic
 

--- a/src/windows/threadw.c
+++ b/src/windows/threadw.c
@@ -196,6 +196,10 @@ void MTY_CondSignalAll(MTY_Cond *ctx)
 	WakeAllConditionVariable(&ctx->cond);
 }
 
+void MTY_MemoryBarrier()
+{
+	MTY_MEMORY_BARRIER();
+}
 
 // Atomic
 


### PR DESCRIPTION
for cross-platform code to use a memory barrier, there must be a function (not just a macro)