### PR TITLE
Bugfix - [Linux] Wait for MapNotify event before toggling fullscreen

### DIFF
--- a/src/unix/linux/x11/dl/libx11.h
+++ b/src/unix/linux/x11/dl/libx11.h
@@ -274,6 +274,16 @@ typedef struct {
 	unsigned long serial;
 	Bool send_event;
 	Display *display;
+	Window event;
+	Window window;
+	Bool override_redirect;
+} XMapEvent;
+
+typedef struct {
+	int type;
+	unsigned long serial;
+	Bool send_event;
+	Display *display;
 	Window window;
 	Window root;
 	Window subwindow;
@@ -398,6 +408,7 @@ typedef union _XEvent {
 	XSelectionEvent xselection;
 	XClientMessageEvent xclient;
 	XGenericEventCookie xcookie;
+	XMapEvent xmap;
 	long pad[24];
 } XEvent;
 


### PR DESCRIPTION
When using some versions of Gnome, opening a fullscreen'd window doesn't properly work. The window is first opened fullscreen'd but immediately toggled back to windowed mode. It seems that's because Gnome is still configuring the window when we request fullscreen, and in those versions it forces windowed mode for some reason. The solution is to wait for Gnome to notify us that it has finished to configure the window, by waiting for the MapNotify event and toggling fullscreen only after having received it.

Note: from our testing, the issue mostly shows up on Ubuntu 24.04, and sometimes on Fedora Workstation when using x11. This doesn't seem to happen on Fedora Atomic distributions, no matter which window manager is in use (tried Gnome and KDE), nor if Wayland or x11 is in use.