### PR TITLE
Bugfix - [Android] Improve gamepad detection (fixes Switch Pro Controller)

### DIFF
--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -597,7 +597,7 @@ static void app_push_controller_event(MTY_App *ctx, const MTY_ControllerEvent *c
 }
 
 JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1button(JNIEnv *env, jobject obj,
-	jint deviceId, jboolean pressed, jint button)
+	jint deviceId, jboolean pressed, jint button, jboolean axis_triggers)
 {
 	MTY_MutexLock(CTX.ctrl_mutex);
 
@@ -632,6 +632,13 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1button(JNIEnv *env, job
 			c->buttons[MTY_CBUTTON_DPAD_LEFT] = pressed && (button == AKEYCODE_DPAD_LEFT || button == AKEYCODE_DPAD_UP_LEFT || button == AKEYCODE_DPAD_DOWN_LEFT);
 			c->buttons[MTY_CBUTTON_DPAD_RIGHT] = pressed && (button == AKEYCODE_DPAD_RIGHT || button == AKEYCODE_DPAD_UP_RIGHT || button == AKEYCODE_DPAD_DOWN_RIGHT);
 			break;
+		}
+	}
+
+	if (!axis_triggers) {
+		switch (button) {
+			case AKEYCODE_BUTTON_L2: c->axes[MTY_CAXIS_TRIGGER_L].value = (pressed ? UINT8_MAX : 0); break;
+			case AKEYCODE_BUTTON_R2: c->axes[MTY_CAXIS_TRIGGER_R].value = (pressed ? UINT8_MAX : 0); break;
 		}
 	}
 


### PR DESCRIPTION
This PR mostly updates two things inside the Android implementation:

### Gamepad detection has been modified to be more restrictive.
Only looking at the event type isn't enough for some devices, where e.g. typing the down dpad button triggers an event whose source has both `SOURCE_KEYBOARD` and `SOURCE_GAMEPAD` flags. We now make use of some more specific mechanisms, where gamepads are prioritized over keyboards:
- If the source device has a gamepad number, that's definitely a gamepad.
- If the source device is a keyboard and can type letters, that's definitely a keyboard.

### Triggers axes are now also being emulated when the device doesn't support it.
That one is more obvious: some device (e.g. the Switch Pro Controller) don't support triggers axes. While the buttons are still being recorded, it's convenient to also have the related axes set when those are pressed.