### PR TITLE
Bugfix - [Android] Change overload of ImageDecoder.createSource

### DIFF
--- a/src/unix/linux/android/image.c
+++ b/src/unix/linux/android/image.c
@@ -21,12 +21,7 @@ void *MTY_DecompressImage(const void *input, size_t size, uint32_t *width, uint3
 	uint32_t *image = NULL;
 
 	// Compressed input
-	jbyteArray jinput = mty_jni_dup(env, input, size);
-	jobject buffer = mty_jni_static_obj(env, "java/nio/ByteBuffer", "wrap",
-		"([B)Ljava/nio/ByteBuffer;", jinput);
-	if (!mty_jni_ok(env))
-		goto except;
-
+	jobject buffer = mty_jni_wrap(env, (void *) input, size);
 	jobject source = mty_jni_static_obj(env, "android/graphics/ImageDecoder", "createSource",
 		"(Ljava/nio/ByteBuffer;)Landroid/graphics/ImageDecoder$Source;", buffer);
 	if (!mty_jni_ok(env))
@@ -69,7 +64,7 @@ void *MTY_DecompressImage(const void *input, size_t size, uint32_t *width, uint3
 
 	except:
 
-	mty_jni_free(env, jinput);
+	mty_jni_free(env, buffer);
 
 	return image;
 }

--- a/src/unix/linux/android/image.c
+++ b/src/unix/linux/android/image.c
@@ -22,8 +22,13 @@ void *MTY_DecompressImage(const void *input, size_t size, uint32_t *width, uint3
 
 	// Compressed input
 	jbyteArray jinput = mty_jni_dup(env, input, size);
+	jobject buffer = mty_jni_static_obj(env, "java/nio/ByteBuffer", "wrap",
+		"([B)Ljava/nio/ByteBuffer;", jinput);
+	if (!mty_jni_ok(env))
+		goto except;
+
 	jobject source = mty_jni_static_obj(env, "android/graphics/ImageDecoder", "createSource",
-		"([B)Landroid/graphics/ImageDecoder$Source;", jinput);
+		"(Ljava/nio/ByteBuffer;)Landroid/graphics/ImageDecoder$Source;", buffer);
 	if (!mty_jni_ok(env))
 		goto except;
 


### PR DESCRIPTION
We were using [ImageDecoder.createSource(byte[])](https://developer.android.com/reference/android/graphics/ImageDecoder#createSource(byte[])), but it was only introduced in API level 32 (Android 12). Instead, we should use [ImageDecoder.createSource(ByteBuffer)](https://developer.android.com/reference/android/graphics/ImageDecoder#createSource(java.nio.ByteBuffer)), introduced in API level 28 (Android 9).