### PR TITLE
Stop grabbing the keyboard when App focus is lost on macOS

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -129,13 +129,11 @@ static void app_apply_cursor(MTY_App *ctx)
 
 static void app_apply_keyboard_state(MTY_App *ctx)
 {
-	if (ctx->grab_kb && ctx->detach == MTY_DETACH_STATE_NONE) {
+	if (!ctx->kb_mode && ctx->grab_kb && ctx->detach == MTY_DETACH_STATE_NONE && MTY_AppIsActive(ctx)) {
 		// Requires "Enable access for assistive devices" checkbox is checked
 		// in the Universal Access preference pane
-		if (!ctx->kb_mode) {
-			ctx->kb_mode = PushSymbolicHotKeyMode(kHIHotKeyModeAllDisabled);
-			CGSSetGlobalHotKeyOperatingMode(CGSMainConnectionID(), CGSGlobalHotKeyDisable);
-		}
+		ctx->kb_mode = PushSymbolicHotKeyMode(kHIHotKeyModeAllDisabled);
+		CGSSetGlobalHotKeyOperatingMode(CGSMainConnectionID(), CGSGlobalHotKeyDisable);
 
 	} else if (ctx->kb_mode) {
 		CGSSetGlobalHotKeyOperatingMode(CGSMainConnectionID(), CGSGlobalHotKeyEnable);

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -258,6 +258,7 @@ static void app_appFunc(id self, SEL _cmd, NSTimer *timer)
 
 	app_poll_clipboard(ctx);
 	app_fix_mouse_buttons(ctx);
+	app_apply_keyboard_state(ctx);
 
 	ctx->cont = ctx->app_func(ctx->opaque);
 


### PR DESCRIPTION
Currently if you call `MTY_AppGrabKeyboard(ctx, true);` and then click to another app, hotkeys like CMD+Tab remain suppressed.

1. Checks if the app is Active when applying keyboard state
2. Move kb_mode check to before checking whether the app is active, to short-circuit
3. Apply keyboard state alongside fixing mouse keys and polling the clipboard