### PR TITLE
Windows app loop busy timeout

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1122,6 +1122,8 @@ void MTY_AppDestroy(MTY_App **app)
 
 void MTY_AppRun(MTY_App *ctx)
 {
+	HANDLE timer = CreateWaitableTimer(NULL, FALSE, NULL);
+
 	for (bool cont = true; cont;) {
 		struct window *window = app_get_main_window(ctx);
 		if (!window)
@@ -1164,6 +1166,9 @@ void MTY_AppRun(MTY_App *ctx)
 		if (ctx->timeout > 0)
 			MTY_Sleep(ctx->timeout);
 	}
+
+	if (timer != NULL)
+		CloseHandle(timer);
 }
 
 void MTY_AppSetTimeout(MTY_App *ctx, uint32_t timeout)

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1163,7 +1163,8 @@ void MTY_AppRun(MTY_App *ctx)
 
 		cont = ctx->app_func(ctx->opaque);
 
-		if (ctx->timeout > 0)
+		// Hard sleep if CreateWaitableTimer is failing
+		if (timer == NULL && ctx->timeout > 0)
 			MTY_Sleep(ctx->timeout);
 	}
 

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1154,7 +1154,7 @@ static bool app_peek_wait(MSG *msg, HANDLE timer, uint32_t timeout, bool *have_m
 
 void MTY_AppRun(MTY_App *ctx)
 {
-	HANDLE timer = CreateWaitableTimer(NULL, FALSE, NULL);
+	HANDLE timer = NULL;
 
 	for (bool cont = true; cont;) {
 		struct window *window = app_get_main_window(ctx);

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1136,6 +1136,20 @@ static void app_prep_wait(HANDLE timer, uint32_t timeout)
 	}
 }
 
+static bool app_peek_wait(MSG *msg, HANDLE timer, uint32_t timeout)
+{
+	// Check for messages first
+	if (PeekMessage(msg, NULL, 0, 0, PM_REMOVE))
+		return true;
+
+	// No messages, check if timer is needed and okay
+	if (timeout == 0 || timer == NULL)
+		return false;
+
+	// Wait for timer
+	return WaitForSingleObject(timer, 1) == WAIT_TIMEOUT;
+}
+
 void MTY_AppRun(MTY_App *ctx)
 {
 	HANDLE timer = CreateWaitableTimer(NULL, FALSE, NULL);
@@ -1167,10 +1181,13 @@ void MTY_AppRun(MTY_App *ctx)
 		// Set up waitable timer
 		app_prep_wait(timer, ctx->timeout);
 
-		// Poll messages belonging to the current (main) thread
-		for (MSG msg; PeekMessage(&msg, NULL, 0, 0, PM_REMOVE);) {
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
+		// Poll messages belonging to the current (main) thread until timeout passes AND queue is exhausted
+		for (MSG msg = {0}; app_peek_wait(&msg, timer, ctx->timeout);) {
+			if (msg.message != WM_NULL) {
+				TranslateMessage(&msg);
+				DispatchMessage(&msg);
+				msg.message = WM_NULL;
+			}
 		}
 
 		// Mouse button state reconciliation

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1120,6 +1120,22 @@ void MTY_AppDestroy(MTY_App **app)
 	*app = NULL;
 }
 
+static void app_prep_wait(HANDLE timer, uint32_t timeout)
+{
+	// Ensure timer is created
+	if (timer == NULL)
+		timer = CreateWaitableTimer(NULL, FALSE, NULL);
+
+	if (timer == NULL)
+		MTY_Log("'CreateWaitableTimer' failed with error 0x%X", GetLastError());
+
+	// Set the timer
+	if (timer != NULL && timeout > 0) {
+		LARGE_INTEGER ft = {.QuadPart = -10000 * (int32_t) timeout};
+		SetWaitableTimer(timer, &ft, 0, NULL, NULL, FALSE);
+	}
+}
+
 void MTY_AppRun(MTY_App *ctx)
 {
 	HANDLE timer = CreateWaitableTimer(NULL, FALSE, NULL);
@@ -1147,6 +1163,9 @@ void MTY_AppRun(MTY_App *ctx)
 
 		// Tray retry in case of failure
 		app_tray_retry(ctx, window);
+
+		// Set up waitable timer
+		app_prep_wait(timer, ctx->timeout);
 
 		// Poll messages belonging to the current (main) thread
 		for (MSG msg; PeekMessage(&msg, NULL, 0, 0, PM_REMOVE);) {

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1136,11 +1136,13 @@ static void app_prep_wait(HANDLE timer, uint32_t timeout)
 	}
 }
 
-static bool app_peek_wait(MSG *msg, HANDLE timer, uint32_t timeout)
+static bool app_peek_wait(MSG *msg, HANDLE timer, uint32_t timeout, bool *have_msg)
 {
 	// Check for messages first
-	if (PeekMessage(msg, NULL, 0, 0, PM_REMOVE))
+	*have_msg = PeekMessage(msg, NULL, 0, 0, PM_REMOVE);
+	if (*have_msg) {
 		return true;
+	}
 
 	// No messages, check if timer is needed and okay
 	if (timeout == 0 || timer == NULL)
@@ -1182,12 +1184,13 @@ void MTY_AppRun(MTY_App *ctx)
 		app_prep_wait(timer, ctx->timeout);
 
 		// Poll messages belonging to the current (main) thread until timeout passes AND queue is exhausted
-		for (MSG msg = {0}; app_peek_wait(&msg, timer, ctx->timeout);) {
-			if (msg.message != WM_NULL) {
-				TranslateMessage(&msg);
-				DispatchMessage(&msg);
-				msg.message = WM_NULL;
-			}
+		bool have_msg = false;
+		for (MSG msg = {0}; app_peek_wait(&msg, timer, ctx->timeout, &have_msg);) {
+			if (!have_msg)
+				continue;
+
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
 		}
 
 		// Mouse button state reconciliation

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1120,19 +1120,19 @@ void MTY_AppDestroy(MTY_App **app)
 	*app = NULL;
 }
 
-static void app_prep_wait(HANDLE timer, uint32_t timeout)
+static void app_prep_wait(HANDLE *timer, uint32_t timeout)
 {
 	// Ensure timer is created
-	if (timer == NULL)
-		timer = CreateWaitableTimer(NULL, FALSE, NULL);
+	if (*timer == NULL)
+		*timer = CreateWaitableTimer(NULL, FALSE, NULL);
 
-	if (timer == NULL)
+	if (*timer == NULL)
 		MTY_Log("'CreateWaitableTimer' failed with error 0x%X", GetLastError());
 
 	// Set the timer
-	if (timer != NULL && timeout > 0) {
+	if (*timer != NULL && timeout > 0) {
 		LARGE_INTEGER ft = {.QuadPart = -10000 * (int32_t) timeout};
-		SetWaitableTimer(timer, &ft, 0, NULL, NULL, FALSE);
+		SetWaitableTimer(*timer, &ft, 0, NULL, NULL, FALSE);
 	}
 }
 
@@ -1181,7 +1181,7 @@ void MTY_AppRun(MTY_App *ctx)
 		app_tray_retry(ctx, window);
 
 		// Set up waitable timer
-		app_prep_wait(timer, ctx->timeout);
+		app_prep_wait(&timer, ctx->timeout);
 
 		// Poll messages belonging to the current (main) thread until timeout passes AND queue is exhausted
 		bool have_msg = false;


### PR DESCRIPTION
Adjusts the MTY_AppRun timeout to work with a windows timer in the `PeekMessage` loop, instead of being a hard Sleep at the end of each app loop.

This reduces artificial gaps between input and other events, and prevents long timeouts (like 100ms or more) from having effects on areas of the OS outside of the application.

Prior to this, a 'long' timeout could have effects on other applications like File Explorer, where dragging the window could hitch slightly once per continuous drag due to a Matoya app not processing the window message queue in a timely manner.

In the event that creating the timer fails, it will be re-attempted each loop. If the timer creation _still_ fails, then the original MTY_Sleep behaviour is used.