### PR TITLE
PARSEC-4655 - Fix inverted horizontal scrolling

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -766,7 +766,7 @@ static void window_scroll_event(struct window *ctx, NSEvent *event)
 	MTY_Event evt = {
 		.type = MTY_EVENT_SCROLL,
 		.window = ctx->window,
-		.scroll.x = lrint(-event.scrollingDeltaX * delta),
+		.scroll.x = lrint(event.scrollingDeltaX * delta),
 		.scroll.y = lrint(event.scrollingDeltaY * delta),
 	};
 


### PR DESCRIPTION
## Research

**tl;dr We don't need to do any inversion of the scrollingDeltaX / scrollingDeltaY. It's handled in the OS before the scroll event happens**

I was poking around the scrolling behavior and noticed that we were always inverting the horizontal scrolling.

I added this logging:

```c
printf("<<<<<< directionInvertedFromDevice: %d %d %d>>>>>>\n", event.directionInvertedFromDevice, lrint(event.scrollingDeltaX * delta), 
```

to see if we needed to actually look at the `directionInvertedFromDevice`. 

With this logging in place and directionInvertedFromDevice is true, the OS already sends the "inverted" values for scroll motion.
- Scrolling Up: Negative scrollingDeltaY
- Scrolling Down: Positive scrollingDeltaY
- Scrolling Left: Negative scrollingDeltaX
- Scrolling Right: Positive scrollingDeltaX

When the directionInvertedFromDevice is false, the opposite occurs:
- Scrolling Up: Positive scrollingDeltaY
- Scrolling Down: Negative scrollingDeltaY
- Scrolling Left: Positive scrollingDeltaX
- Scrolling Right: Negative scrollingDeltaX


So when we were inverting the DeltaX we caused the opposite behavior to happen. When inversion should be true, we caused inversion to be false and vise versa.


## Fix

Removed the inversion in the deltaX. We're going to rely on the OS to send the correct scrolling values.