### PR TITLE
PARSEC-5572 - Support additional character sets on macOS

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -782,8 +782,8 @@ static bool is_function_key(NSEvent *event) {
 		return false;
 
 	unichar c = [s characterAtIndex:0];
-	printf("%d %x\n", c, c);
-    return (c >= 0xF700 && c <= 0xF8FF);
+	// Ref: https://developer.apple.com/documentation/appkit/function-key-unicode-values?language=objc
+	return (c >= 0xF700 && c <= 0xF8FF);
 }
 
 static void window_text_event(struct window *ctx, const char *text)

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -801,7 +801,6 @@ static void window_text_event(struct window *ctx, const char *text)
 	};
 
 	snprintf(evt.text, 8, "%s", text);
-
 	ctx->app->event_func(&evt, ctx->app->opaque);
 }
 
@@ -1015,7 +1014,6 @@ static void window_keyUp(NSWindow *self, SEL _cmd, NSEvent *event)
 static void window_keyDown(NSWindow *self, SEL _cmd, NSEvent *event)
 {
 	struct window *ctx = OBJC_CTX();
-
 	if (!ctx)
 		return;
 

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -791,8 +791,8 @@ static void window_text_event(struct window *ctx, const char *text)
 	if (!text || !text[0])
 		return; // Empty event
 
-	bool is_ascii_control_character = strlen(text) == 1 ? text[0] < 0x20 || text[0] == 0x7F : false;
-	if (is_ascii_control_character)
+	unsigned char c = (unsigned char) text[0];
+	if (text[1] == '\0' && (c < 0x20 || c == 0x7F))
 		return; // Ignore ASCII control characters
 
 	MTY_Event evt = {

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -793,9 +793,10 @@ static void window_text_event(struct window *ctx, const char *text)
 		return;
 
 	bool is_ascii_control_character = strlen(text) == 1 ? text[0] < 0x20 || text[0] == 0x7F : false;
-	if (is_ascii_control_character)
+	if (is_ascii_control_character) {
 		// Ignore ASCII control characters
 		return;
+	}
 
 	MTY_Event evt = {
 		.type = MTY_EVENT_TEXT,
@@ -1017,10 +1018,15 @@ static void window_keyUp(NSWindow *self, SEL _cmd, NSEvent *event)
 static void window_keyDown(NSWindow *self, SEL _cmd, NSEvent *event)
 {
 	struct window *ctx = OBJC_CTX();
-	if (!ctx)
+
+	if (!ctx) {
 		return;
-	if (!is_function_key(event))
+	}
+
+	if (!is_function_key(event)) {
 		window_text_event(ctx, [event.characters UTF8String]);
+	}
+
 	window_keyboard_event(ctx, event.keyCode, event.modifierFlags, true, event.isARepeat);
 }
 

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -776,6 +776,16 @@ static void window_scroll_event(struct window *ctx, NSEvent *event)
 
 // Keyboard
 
+static bool is_function_key(NSEvent *event) {
+	NSString *s = event.characters;
+	if (!s || !s.length)
+		return false;
+
+	unichar c = [s characterAtIndex:0];
+	printf("%d %x\n", c, c);
+    return (c >= 0xF700 && c <= 0xF8FF);
+}
+
 static void window_text_event(struct window *ctx, const char *text)
 {
 	if (!text || !text[0] || (strlen(text) == 1 && (text[0] < 0x20 || text[0] == 0x7F)))
@@ -1004,8 +1014,8 @@ static void window_keyDown(NSWindow *self, SEL _cmd, NSEvent *event)
 	struct window *ctx = OBJC_CTX();
 	if (!ctx)
 		return;
-
-	window_text_event(ctx, [event.characters UTF8String]);
+	if (!is_function_key(event))
+		window_text_event(ctx, [event.characters UTF8String]);
 	window_keyboard_event(ctx, event.keyCode, event.modifierFlags, true, event.isARepeat);
 }
 

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -778,17 +778,18 @@ static void window_scroll_event(struct window *ctx, NSEvent *event)
 
 static void window_text_event(struct window *ctx, const char *text)
 {
-	// Make sure visible ASCII
-	if (text && text[0] && text[0] >= 0x20 && text[0] != 0x7F) {
-		MTY_Event evt = {
-			.type = MTY_EVENT_TEXT,
-			.window = ctx->window,
-		};
+	if (!text || !text[0] || (strlen(text) == 1 && (text[0] < 0x20 || text[0] == 0x7F)))
+		// Ignore ASCII control characters
+		return;
 
-		snprintf(evt.text, 8, "%s", text);
+	MTY_Event evt = {
+		.type = MTY_EVENT_TEXT,
+		.window = ctx->window,
+	};
 
-		ctx->app->event_func(&evt, ctx->app->opaque);
-	}
+	snprintf(evt.text, 8, "%s", text);
+
+	ctx->app->event_func(&evt, ctx->app->opaque);
 }
 
 static void window_keyboard_event(struct window *ctx, uint16_t key_code, NSEventModifierFlags flags,

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -800,7 +800,7 @@ static void window_text_event(struct window *ctx, const char *text)
 		.window = ctx->window,
 	};
 
-	snprintf(evt.text, 8, "%s", text);
+	snprintf(evt.text, sizeof(evt.text), "%s", text);
 	ctx->app->event_func(&evt, ctx->app->opaque);
 }
 

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -788,7 +788,12 @@ static bool is_function_key(NSEvent *event) {
 
 static void window_text_event(struct window *ctx, const char *text)
 {
-	if (!text || !text[0] || (strlen(text) == 1 && (text[0] < 0x20 || text[0] == 0x7F)))
+	if (!text || !text[0])
+		// Empty event
+		return;
+
+	bool is_ascii_control_character = strlen(text) == 1 ? text[0] < 0x20 || text[0] == 0x7F : false;
+	if (is_ascii_control_character)
 		// Ignore ASCII control characters
 		return;
 

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -789,14 +789,11 @@ static bool is_function_key(NSEvent *event) {
 static void window_text_event(struct window *ctx, const char *text)
 {
 	if (!text || !text[0])
-		// Empty event
-		return;
+		return; // Empty event
 
 	bool is_ascii_control_character = strlen(text) == 1 ? text[0] < 0x20 || text[0] == 0x7F : false;
-	if (is_ascii_control_character) {
-		// Ignore ASCII control characters
-		return;
-	}
+	if (is_ascii_control_character)
+		return; // Ignore ASCII control characters
 
 	MTY_Event evt = {
 		.type = MTY_EVENT_TEXT,
@@ -1019,13 +1016,11 @@ static void window_keyDown(NSWindow *self, SEL _cmd, NSEvent *event)
 {
 	struct window *ctx = OBJC_CTX();
 
-	if (!ctx) {
+	if (!ctx)
 		return;
-	}
 
-	if (!is_function_key(event)) {
+	if (!is_function_key(event))
 		window_text_event(ctx, [event.characters UTF8String]);
-	}
 
 	window_keyboard_event(ctx, event.keyCode, event.modifierFlags, true, event.isARepeat);
 }


### PR DESCRIPTION
Update our text event handler to allow user to supply other unicode characters that are beyond the ascii character set.

## QA Notes
### Summary of changes
Update our handling of IMGUI text input to support additional characters. The method that sends the keypress events to the host is not affected (`window_keyboard_event`)

### Platforms Affected
- macOS

### Test cases performed

- macOS 26.2  / macOS 15.3.1
    - Able to type additional characters like æ (Option + ') Æ (Option + Shift + ') in the login screen (email and password) as well as the host search field.
    - Control characters, like backspace, are ignored and processed correctly by IMGUI
    - Able to pass additional characters when connected to macOS host (both 26.2 and 15.3.1) [This was working previously]
    - Connected to Windows host and keyboard inputs are working as expected.

### Test cases untested
- More thorough ASCII control codes and other Unicode control / odd characters.
    - I went through some of them, like Forward Delete on macOS but we are allowing additional unicode characters through that was previously dropped.