### PR TITLE
Revert "PARSEC-4655 - Fix inverted horizontal scrolling (#168)"

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -766,7 +766,9 @@ static void window_scroll_event(struct window *ctx, NSEvent *event)
 	MTY_Event evt = {
 		.type = MTY_EVENT_SCROLL,
 		.window = ctx->window,
-		.scroll.x = lrint(event.scrollingDeltaX * delta),
+		// macOS and Windows treat horizontal scrolling diffently,
+		// so invert the horizontal delta to match Windows behavior.
+		.scroll.x = lrint(-event.scrollingDeltaX * delta),
 		.scroll.y = lrint(event.scrollingDeltaY * delta),
 	};
 

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -766,7 +766,7 @@ static void window_scroll_event(struct window *ctx, NSEvent *event)
 	MTY_Event evt = {
 		.type = MTY_EVENT_SCROLL,
 		.window = ctx->window,
-		// macOS and Windows treat horizontal scrolling diffently,
+		// macOS and Windows treat horizontal scrolling differently,
 		// so invert the horizontal delta to match Windows behavior.
 		.scroll.x = lrint(-event.scrollingDeltaX * delta),
 		.scroll.y = lrint(event.scrollingDeltaY * delta),


### PR DESCRIPTION
This reverts commit 0c401eb0869f0b4664b73b59b9d3ff4d3515ffd8. Associated PR: https://github.com/parsec-cloud/libmatoya/pull/168

The macOS scroll direction is inverted so it macOS clients work as expected on Windows hosts. To fix the horizontal scroll issue on macOS, the fix must be applied on the host side and not the client side.