### PR TITLE
[Bugfix] PARSEC-5324 Do string memory conversion before passing to postMessage

### DIFF
--- a/src/unix/web/matoya-worker.js
+++ b/src/unix/web/matoya-worker.js
@@ -782,7 +782,7 @@ const MTY_WEB_API = {
 		return buf;
 	},
 	web_set_clipboard: function (text) {
-		postMessage({type: 'set-clip', text});
+		postMessage({type: 'set-clip', text: mty_str_to_js(text)});
 	},
 	web_set_pointer_lock: function (enable) {
 		postMessage({type: 'pointer-lock', enable});

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -981,7 +981,7 @@ async function mty_thread_message(ev) {
 			mty_signal(msg.sync);
 			break;
 		case 'set-clip':
-			navigator.clipboard.writeText(mty_str_to_js(msg.text));
+			navigator.clipboard.writeText(msg.text);
 			break;
 		case 'pointer-lock':
 			mty_set_pointer_lock(msg.enable);


### PR DESCRIPTION
Fixes setting the clipboard on web. Memory used for the clipboard setting is not shared between threads so must be converted to a string before passing between threads.

Reading the clipboard works but currently there is not widely supported method to get notified when the clipboard contents change (see [Docs](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/clipboardchange_event) and [blog post 1](https://developer.chrome.com/blog/clipboardchange)). The best looking method only recently got added to chrome browsers, firefox and safari don't offer support