### PR TITLE
Include debug symbols in non-debug builds.

### DIFF
--- a/makefile
+++ b/makefile
@@ -106,13 +106,14 @@ FLAGS = \
 	/nologo
 
 LIB_FLAGS = \
-	/nologo
+	/nologo \
+	/LTCG
 
 !IFDEF DEBUG
 FLAGS = $(FLAGS) /Ob0 /Zi /Oy-
 DEFS = $(DEFS) -DMTY_VK_DEBUG
 !ELSE
-FLAGS = $(FLAGS) /O2 /GS- /Gw
+FLAGS = $(FLAGS) /O2 /GS- /Gw /Zi
 !ENDIF
 
 CFLAGS = $(INCLUDES) $(DEFS) $(FLAGS)


### PR DESCRIPTION
Minor change to always create obj files which include debug information. This won't have any impact until https://github.com/parsec-cloud/parsec/pull/2154 lands as Parsec is still linked without the /DEBUG option so any debug information is discarded at link time.