### PR TITLE
Add additional error code for closed ws connection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @parsec-cloud/native

--- a/src/windows/ws.c
+++ b/src/windows/ws.c
@@ -104,9 +104,6 @@ static void WINAPI ws_async(HINTERNET hInternet, DWORD_PTR dwContext, DWORD dwIn
 			// "The operation was canceled, usually because the handle on which the request was operating was closed before the operation completed."
 			else if (result->dwError == ERROR_WINHTTP_OPERATION_CANCELLED)
 				ctx->closed = true;
-			// "The server name cannot be resolved."
-			else if (result->dwError == ERROR_WINHTTP_NAME_NOT_RESOLVED)
-				ctx->closed = true;
 
 			if (!ctx->closed)
 				MTY_Log("WebSocket error: dwResult:%u, dwError:0x%X", result->dwResult, result->dwError);

--- a/src/windows/ws.c
+++ b/src/windows/ws.c
@@ -104,6 +104,9 @@ static void WINAPI ws_async(HINTERNET hInternet, DWORD_PTR dwContext, DWORD dwIn
 			// "The operation was canceled, usually because the handle on which the request was operating was closed before the operation completed."
 			else if (result->dwError == ERROR_WINHTTP_OPERATION_CANCELLED)
 				ctx->closed = true;
+			// "The server name cannot be resolved."
+			else if (result->dwError == ERROR_WINHTTP_NAME_NOT_RESOLVED)
+				ctx->closed = true;
 
 			if (!ctx->closed)
 				MTY_Log("WebSocket error: dwResult:%u, dwError:0x%X", result->dwResult, result->dwError);

--- a/src/windows/ws.c
+++ b/src/windows/ws.c
@@ -101,6 +101,9 @@ static void WINAPI ws_async(HINTERNET hInternet, DWORD_PTR dwContext, DWORD dwIn
 			// "The connection with the server has been reset or terminated, or an incompatible SSL protocol was encountered."
 			if (result->dwError == ERROR_WINHTTP_CONNECTION_ERROR)
 				ctx->closed = true;
+			// "The operation was canceled, usually because the handle on which the request was operating was closed before the operation completed."
+			else if (result->dwError == ERROR_WINHTTP_OPERATION_CANCELLED)
+				ctx->closed = true;
 
 			if (!ctx->closed)
 				MTY_Log("WebSocket error: dwResult:%u, dwError:0x%X", result->dwResult, result->dwError);


### PR DESCRIPTION
Add additional error code on the websocket implementation that indicates the underlying HTTP socket is closed.

Related to: https://github.com/parsec-cloud/parsec/pull/2130